### PR TITLE
Added unit test for reads_at_locus dataframe, changed noisy info logging to debug

### DIFF
--- a/isovar/common.py
+++ b/isovar/common.py
@@ -91,3 +91,10 @@ def make_prefix_suffix_pairs(variant_reads):
     variant_seq = get_variant_nucleotides(variant_reads)
     pairs = [(r.prefix, r.suffix) for r in variant_reads]
     return variant_seq, pairs
+
+
+def list_to_string(list_of_anything, sep=";"):
+    """
+    Helper function used for building the fields of a printable dataframe
+    """
+    return sep.join(str(x) for x in list_of_anything)

--- a/isovar/default_parameters.py
+++ b/isovar/default_parameters.py
@@ -21,7 +21,7 @@ arguments of different scripts.
 """
 
 # lowest mapping quality (MAPQ) value to allow for RNAseq reads
-MIN_READ_MAPPING_QUALITY = 0
+MIN_READ_MAPPING_QUALITY = 1
 
 # use a read even if it's been marked as a duplicate?
 USE_DUPLICATE_READS = False

--- a/isovar/default_parameters.py
+++ b/isovar/default_parameters.py
@@ -21,6 +21,25 @@ arguments of different scripts.
 """
 
 # lowest mapping quality (MAPQ) value to allow for RNAseq reads
+# Rationale for a default value of 1:
+#   RNA aligners such as STAR typically reserve MAPQ=255 for unique alignments
+#   and then have some heuristic for decreasing MAPQ as a function of the number
+#   of locations to which a read can map.
+#   Continuing to use STAR as an example, here's a guide to its MAPQ values:
+#       255 = uniquely mapped reads
+#       3 = read maps to 2 locations
+#       2 = read maps to 3 locations
+#       1 = reads maps to 4-9 locations
+#       0 = reads maps to 10 or more locations
+#   (from http://seqanswers.com/forums/archive/index.php/t-27470.html)
+#   Since there's no bound on just how bad MAPQ=0 really can be, it seems
+#   wises to exclude those reads but still allow 9 candidate locations
+#   per read.
+#
+#   The exact numbers differ with other aligners but the basic principle is the
+#   same: MAPQ=0 might have an extremely large number of mapping locations
+#   (probably due to low complexity of the sequence) but anything with MAPQ=1
+#   is probably useful.
 MIN_READ_MAPPING_QUALITY = 1
 
 # use a read even if it's been marked as a duplicate?

--- a/test/test_protein_sequence.py
+++ b/test/test_protein_sequence.py
@@ -167,12 +167,13 @@ def test_variants_to_protein_sequences_dataframe_one_sequence_per_variant():
 
 def test_variants_to_protein_sequences_dataframe_filtered_all_reads_by_mapping_quality():
     # since the B16 BAM has all MAPQ=255 values then all the reads should get dropped
+    # if we set the minimum quality to 256
     variants = load_vcf("data/b16.f10/b16.vcf")
     samfile = load_bam("data/b16.f10/b16.combined.sorted.bam")
     df = variants_to_protein_sequences_dataframe(
         variants,
         samfile,
-        min_mapping_quality=100,
+        min_mapping_quality=256,
         max_protein_sequences_per_variant=1)
     print(df)
     eq_(
@@ -180,8 +181,8 @@ def test_variants_to_protein_sequences_dataframe_filtered_all_reads_by_mapping_q
         0,
         "Expected 0 entries, got %d" % (len(df),))
 
-def test_variants_to_protein_sequences_dataframe_protein_sequence_length():
-    # since the B16 BAM has all MAPQ=255 values then all the reads should get dropped
+def test_variants_to_protein_sequences_dataframe_desired_length():
+    # make sure that the protein sequencces we get back are the length we asked for 
     variants = load_vcf("data/b16.f10/b16.vcf")
     samfile = load_bam("data/b16.f10/b16.combined.sorted.bam")
 

--- a/test/test_protein_sequence.py
+++ b/test/test_protein_sequence.py
@@ -181,7 +181,7 @@ def test_variants_to_protein_sequences_dataframe_filtered_all_reads_by_mapping_q
         0,
         "Expected 0 entries, got %d" % (len(df),))
 
-def test_variants_to_protein_sequences_dataframe_desired_length():
+def test_variants_to_protein_sequences_dataframe_protein_sequence_length():
     # make sure that the protein sequencces we get back are the length we asked for 
     variants = load_vcf("data/b16.f10/b16.vcf")
     samfile = load_bam("data/b16.f10/b16.combined.sorted.bam")


### PR DESCRIPTION
Hopefully fixes https://github.com/hammerlab/isovar/issues/13 but uncovered https://github.com/hammerlab/isovar/issues/14.

Small but important changes to treatment of MAPQ:
- MAPQ=255 indicates a missing mapping quality for some DNA aligners but for RNA this actually means unique alignment!
- If we can use MAPQ=255 reads then we can re-enable MAPQ filtering (by setting the minimum value to 1). 