### PR TITLE
Trim variant sequences by coverage when matching to reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ cache:
   # cache directory used for Ensembl downloads of GTF and FASTA files
   # along with the indexed db of intervals and ID mappings and pickles
   # of sequence dictionaries
-  directories: /home/travis/.cache/pyensembl/
+  directories:
+  - /home/travis/.cache/pyensembl/
+  - /home/travis/.cache/pyensembl/GRCh37/ensembl75/
+  - /home/travis/.cache/pyensembl/GRCh37/ensembl85/
 before_install:
   # Commands below copied from: http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the

--- a/isovar/allele_reads.py
+++ b/isovar/allele_reads.py
@@ -18,7 +18,7 @@ allele (ref, alt, or otherwise), and suffix portions
 """
 
 from __future__ import print_function, division, absolute_import
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 import logging
 
 from .locus_reads import locus_read_generator
@@ -34,23 +34,40 @@ from .string_helpers import convert_from_bytes_if_necessary, trim_N_nucleotides
 
 logger = logging.getLogger(__name__)
 
-# subclassing from namedtuple to get a lightweight object with built-in
-# hashing and comparison while also being able to add methods
-AlleleReadBase = namedtuple(
-    "AlleleRead",
-    "prefix allele suffix name sequence")
 
-class AlleleRead(AlleleReadBase):
-    def __new__(cls, prefix, allele, suffix, name):
-        return AlleleReadBase(
-            prefix=prefix,
-            allele=allele,
-            suffix=suffix,
-            name=name,
-            sequence=prefix + allele + suffix)
+class AlleleRead(object):
+    __slots__ = ["prefix", "allele", "suffix", "name", "sequence"]
+
+    def __init__(self, prefix, allele, suffix, name):
+        self.prefix = prefix
+        self.allele = allele
+        self.suffix = suffix
+        self.name = name
+        self.sequence = prefix + allele + suffix
 
     def __len__(self):
-        return len(self.prefix) + len(self.allele) + len(self.suffix)
+        return len(self.sequence)
+
+    def __str__(self):
+        return "AlleleRead(prefix='%s', allele='%s', suffix='%s', name='%s')" % (
+            self.prefix,
+            self.allele,
+            self.suffix,
+            self.name)
+
+    def __repr__(self):
+        return str(self)
+
+    def __hash__(self):
+        return hash(self.sequence)
+
+    def __eq__(self, other):
+        return (
+            other.__class__ is AlleleRead and
+            self.prefix == other.prefix and
+            self.allele == other.allele and
+            self.suffix == other.suffix and
+            self.name == other.name)
 
     @classmethod
     def from_locus_read(cls, locus_read, n_ref):

--- a/isovar/allele_reads.py
+++ b/isovar/allele_reads.py
@@ -30,12 +30,12 @@ from .default_parameters import (
 from .variant_helpers import trim_variant
 from .dataframe_builder import DataFrameBuilder
 from .string_helpers import convert_from_bytes_if_necessary, trim_N_nucleotides
-
+from .compact_object import CompactObject
 
 logger = logging.getLogger(__name__)
 
 
-class AlleleRead(object):
+class AlleleRead(CompactObject):
     __slots__ = ["prefix", "allele", "suffix", "name", "sequence"]
 
     def __init__(self, prefix, allele, suffix, name):
@@ -47,27 +47,6 @@ class AlleleRead(object):
 
     def __len__(self):
         return len(self.sequence)
-
-    def __str__(self):
-        return "AlleleRead(prefix='%s', allele='%s', suffix='%s', name='%s')" % (
-            self.prefix,
-            self.allele,
-            self.suffix,
-            self.name)
-
-    def __repr__(self):
-        return str(self)
-
-    def __hash__(self):
-        return hash(self.name)
-
-    def __eq__(self, other):
-        return (
-            other.__class__ is AlleleRead and
-            self.prefix == other.prefix and
-            self.allele == other.allele and
-            self.suffix == other.suffix and
-            self.name == other.name)
 
     @classmethod
     def from_locus_read(cls, locus_read, n_ref):

--- a/isovar/allele_reads.py
+++ b/isovar/allele_reads.py
@@ -59,7 +59,7 @@ class AlleleRead(object):
         return str(self)
 
     def __hash__(self):
-        return hash(self.sequence)
+        return hash(self.name)
 
     def __eq__(self, other):
         return (

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -19,10 +19,9 @@ import logging
 # I'd rather just use list.copy but Python 2.7 doesn't support it
 from copy import copy
 
+from .default_parameters import MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE
 
 logger = logging.getLogger(__name__)
-
-MIN_OVERLAP_SIZE = 30
 
 def sort_by_decreasing_prefix_length(seq):
     """
@@ -64,7 +63,9 @@ def sort_by_decreasing_total_length(seq):
     """
     return -len(seq.sequence)
 
-def greedy_merge(variant_sequences, min_overlap_size=MIN_OVERLAP_SIZE):
+def greedy_merge(
+        variant_sequences,
+        min_overlap_size=MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE):
     """
     Greedily merge overlapping sequences into longer sequences.
 
@@ -153,7 +154,7 @@ def sort_by_decreasing_read_count_and_sequence_lenth(variant_sequence):
 
 def iterative_overlap_assembly(
         variant_sequences,
-        min_overlap_size=30,
+        min_overlap_size=MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
         n_merge_iters=2):
     """
     Assembles longer sequences from reads centered on a variant by alternating

--- a/isovar/compact_object.py
+++ b/isovar/compact_object.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+from itertools import chain
+
+class CompactObject(object):
+    """
+    Base class for objects which define their fields
+    via __slots__ to decrease memory footporint and
+    speed up field access.
+    """
+    __slots__ = []
+
+    def _values(self):
+        return tuple(
+            getattr(self, name)
+            for name in self._fields())
+
+    @classmethod
+    def _fields(cls):
+        """
+        Get all field names of this object by traversing
+        its inheritance hierarchy in reverse order and
+        concatenating the names in __slots__.
+        """
+        inherited_class_order = reversed(cls.__mro__)
+        return tuple(
+            chain.from_iterable(
+                getattr(cls, '__slots__', [])
+                for cls in inherited_class_order))
+
+    def __str__(self):
+        raise NotImplementedError("__str__ must be implemented")
+
+    def __repr__(self):
+        return str(self)
+
+    def __hash__(self):
+        return hash(self._values())
+
+    def __eq__(self, other):
+        return (
+            self.__class__ is other.__class__ and
+            self._values() == other._values())

--- a/isovar/compact_object.py
+++ b/isovar/compact_object.py
@@ -24,13 +24,13 @@ class MetaclassCollectSlots(type):
     called _fields (which is also how namedtuple objects expose their
     field names).
     """
-    def __init__(self, name, bases, dictionary):
+    def __init__(self, *args, **kwargs):
         """
         Get all field names of this class by traversing
         its inheritance hierarchy in reverse order and
         concatenating the names in __slots__.
         """
-        type.__init__(self, name, bases, dictionary)
+        super(MetaclassCollectSlots, self).__init__(*args, **kwargs)
         inherited_class_order = reversed(self.__mro__)
         self._fields = tuple(
             chain.from_iterable(

--- a/isovar/dataframe_builder.py
+++ b/isovar/dataframe_builder.py
@@ -34,6 +34,7 @@ class DataFrameBuilder(object):
     def __init__(
             self,
             element_class,
+            field_names=None,
             exclude=set([]),
             converters={},
             rename_dict={},
@@ -44,8 +45,11 @@ class DataFrameBuilder(object):
         Parameters
         ----------
         element_class : type
-            Expected to a have a class-member named '_fields' which is a list
-            of field names.
+            Class of elements in this collection.
+
+        field_name : list, optional
+            If not given then we expect element_class to have a class member
+            named '_fields' which is a list of field names.
 
         exclude : set
             Field names from element_class which should be used as columns for
@@ -81,10 +85,23 @@ class DataFrameBuilder(object):
         self.variant_columns = variant_columns
         self.convert_collections_to_size = convert_collections_to_size
 
+        if field_names is None:
+            assert hasattr(element_class, "_fields"), (
+                "Expected %s to have member called `_fields`" % element_class)
+            field_names = element_class._fields
+
+        if hasattr(field_names, "__call__"):
+            # we expect field names to either be a list or a
+            # method that when called returns a list. This is to
+            # accomodate the difference between namedtuples, which
+            # have a class property _fields and objects which
+            # have classmethods instead.
+            field_names = field_names()
+
         # remove specified field names without changing the order of the others
         self.original_field_names = [
             x
-            for x in element_class._fields
+            for x in field_names
             if x not in exclude
         ]
 

--- a/isovar/dataframe_builder.py
+++ b/isovar/dataframe_builder.py
@@ -90,14 +90,6 @@ class DataFrameBuilder(object):
                 "Expected %s to have member called `_fields`" % element_class)
             field_names = element_class._fields
 
-        if hasattr(field_names, "__call__"):
-            # we expect field names to either be a list or a
-            # method that when called returns a list. This is to
-            # accomodate the difference between namedtuples, which
-            # have a class property _fields and objects which
-            # have classmethods instead.
-            field_names = field_names()
-
         # remove specified field names without changing the order of the others
         self.original_field_names = [
             x

--- a/isovar/default_parameters.py
+++ b/isovar/default_parameters.py
@@ -77,3 +77,9 @@ MAX_PROTEIN_SEQUENCES_PER_VARIANT = 1
 # sequences from multiple reads which only partially
 # overlap (rather than fully spanning a coding sequence)
 VARIANT_CDNA_SEQUENCE_ASSEMBLY = False
+
+# Only merge variant cDNA sequences which at least share
+# this number of nucleotides. Should be sufficiently high
+# to minimize false assembly of isoforms which don't
+# actually exist.
+MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE = 30

--- a/isovar/dna.py
+++ b/isovar/dna.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+
+dna_complement_dictionary = {
+    "A": "T",
+    "T": "A",
+    "C": "G",
+    "G": "C",
+}
+
+dna_nucleotides = list(sorted(dna_complement_dictionary.keys()))
+
+dna_nucleotide_to_index = {c: i for (i, c) in enumerate(dna_nucleotides)}
+
+index_to_dna_nucleotide = {i: c for (i, c) in enumerate(dna_nucleotides)}
+
+def complement_dna(seq):
+    return "".join(dna_complement_dictionary[nt] for nt in seq)
+
+def reverse_complement_dna(seq):
+    return complement_dna(seq)[::-1]

--- a/isovar/effect_prediction.py
+++ b/isovar/effect_prediction.py
@@ -44,32 +44,33 @@ def predicted_coding_effects_with_mutant_sequence(
         if not transcript.complete:
             logger.info(
                 "Skipping transcript %s for variant %s because it's incomplete",
-                    transcript,
-                    variant)
+                transcript.name,
+                variant)
             continue
 
         if transcript_id_whitelist and transcript.id not in transcript_id_whitelist:
             logger.info(
                 "Skipping transcript %s for variant %s because it's not one of %d allowed",
-                    transcript,
-                    variant,
-                    len(transcript_id_whitelist))
+                transcript.name,
+                variant,
+                len(transcript_id_whitelist))
             continue
         effects.append(variant.effect_on_transcript(transcript))
 
     effects = EffectCollection(effects)
 
     n_total_effects = len(effects)
-    logger.info("Predicted %d effects for variant %s" % (
+    logger.info("Predicted total %d effects for variant %s" % (
         n_total_effects,
         variant))
 
     nonsynonymous_coding_effects = effects.drop_silent_and_noncoding()
     logger.info(
-        "Keeping %d/%d non-synonymous coding effects for %s" % (
-            len(nonsynonymous_coding_effects),
-            n_total_effects,
-            variant))
+        "Keeping %d/%d effects which affect protein coding sequence for %s: %s",
+        len(nonsynonymous_coding_effects),
+        n_total_effects,
+        variant,
+        nonsynonymous_coding_effects)
 
     usable_effects = [
         effect
@@ -77,10 +78,10 @@ def predicted_coding_effects_with_mutant_sequence(
         if effect.mutant_protein_sequence is not None
     ]
     logger.info(
-        "Keeping %d/%d effects with predictable AA sequences for %s",
-            len(usable_effects),
-            len(nonsynonymous_coding_effects),
-            variant)
+        "Keeping %d effects with predictable AA sequences for %s: %s",
+        len(usable_effects),
+        variant,
+        usable_effects)
     return usable_effects
 
 def reference_transcripts_for_variant(variant, transcript_id_whitelist=None):

--- a/isovar/protein_sequences.py
+++ b/isovar/protein_sequences.py
@@ -94,7 +94,7 @@ class ProteinSequence(ProteinSequenceBase):
         gene_names = set([])
         transcript_ids = set([])
         for translation in translations:
-            for read in translation.variant_sequence.reads:
+            for read in translation.reads:
                 read_name_to_reads[read.name] = read
             for transcript in translation.reference_context.transcripts:
                 transcript_ids.add(transcript.id)

--- a/isovar/reference_coding_sequence_key.py
+++ b/isovar/reference_coding_sequence_key.py
@@ -56,7 +56,7 @@ class ReferenceCodingSequenceKey(ReferenceSequenceKey):
             contains_five_prime_utr,
             amino_acids_before_variant):
         ReferenceSequenceKey.__init__(
-            self=self,
+            self,
             strand=strand,
             sequence_before_variant_locus=sequence_before_variant_locus,
             sequence_at_variant_locus=sequence_at_variant_locus,

--- a/isovar/reference_coding_sequence_key.py
+++ b/isovar/reference_coding_sequence_key.py
@@ -67,19 +67,6 @@ class ReferenceCodingSequenceKey(ReferenceSequenceKey):
         self.contains_five_prime_utr = contains_five_prime_utr
         self.amino_acids_before_variant = amino_acids_before_variant
 
-    def __str__(self):
-        return (
-            "ReferenceCodingSequenceKey("
-            "strand='%s', "
-            "sequence_before_variant_locus='%s', "
-            "sequence_at_variant_locus='%s', "
-            "sequence_after_variant_locus='%s', "
-            "offset_to_first_complete_codon=%d, "
-            "contains_start_codon=%s, "
-            "overlaps_start_codon=%s, "
-            "contains_five_prime_utr=%s, "
-            "amino_acids_before_variant=%s)") % self._values()
-
     @classmethod
     def from_variant_and_transcript_and_sequence_key(
             cls, variant, transcript, sequence_key):
@@ -183,21 +170,21 @@ class ReferenceCodingSequenceKey(ReferenceSequenceKey):
         if not transcript.contains_start_codon:
             logger.info(
                 "Expected transcript %s for variant %s to have start codon",
-                transcript,
+                transcript.name,
                 variant)
             return None
 
         if not transcript.contains_stop_codon:
             logger.info(
                 "Expected transcript %s for variant %s to have stop codon",
-                transcript,
+                transcript.name,
                 variant)
             return None
 
         if not transcript.protein_sequence:
             logger.info(
                 "Expected transript %s for variant %s to have protein sequence",
-                transcript,
+                transcript.name,
                 variant)
             return None
 
@@ -210,7 +197,7 @@ class ReferenceCodingSequenceKey(ReferenceSequenceKey):
             logger.info(
                 "No sequence key for variant %s on transcript %s",
                 variant,
-                transcript)
+                transcript.name)
             return None
 
         return cls.from_variant_and_transcript_and_sequence_key(

--- a/isovar/reference_coding_sequence_key.py
+++ b/isovar/reference_coding_sequence_key.py
@@ -14,92 +14,80 @@
 
 from __future__ import print_function, division, absolute_import
 import logging
-from collections import namedtuple
 
 from .variant_helpers import interbase_range_affected_by_variant_on_transcript
 from .reference_sequence_key import ReferenceSequenceKey
 
 logger = logging.getLogger(__name__)
 
-class ReferenceCodingSequenceKey(
-        namedtuple(
-            "ReferenceCodingSequenceKey",
-            ReferenceSequenceKey._fields + (
-                # if the reference context includes the 5' UTR then
-                # this is the offset to the start codon, otherwise it's the
-                # offset needed to get the first base of a codon
-                "offset_to_first_complete_codon",
-                # does this context overlap a start codon?
-                "overlaps_start_codon",
-                # does this context contain the whole trinucleotide start codon?
-                "contains_start_codon",
-                # does this context contain any UTR bases?
-                "contains_five_prime_utr",
-                # translation of complete codons in the reference context
-                # before the variant
-                "amino_acids_before_variant"))):
-
+class ReferenceCodingSequenceKey(ReferenceSequenceKey):
     """
     ReferenceCodingSequenceKey includes all the fields of a ReferenceSequenceKey,
     and additionally tracks the reading frame and information about where the
     start codon and 5' UTR are relative to this sequence fragment.
     """
 
+    # additional fields on top of ReferenceSequenceKey
+    __slots__ = [
+        # if the reference context includes the 5' UTR then
+        # this is the offset to the start codon, otherwise it's the
+        # offset needed to get the first base of a codon
+        "offset_to_first_complete_codon",
+        # does this context overlap a start codon?
+        "overlaps_start_codon",
+        # does this context contain the whole trinucleotide start codon?
+        "contains_start_codon",
+        # does this context contain any UTR bases?
+        "contains_five_prime_utr",
+        # translation of complete codons in the reference context
+        # before the variant
+        "amino_acids_before_variant"
+    ]
+
+    def __init__(
+            self,
+            strand,
+            sequence_before_variant_locus,
+            sequence_at_variant_locus,
+            sequence_after_variant_locus,
+            offset_to_first_complete_codon,
+            contains_start_codon,
+            overlaps_start_codon,
+            contains_five_prime_utr,
+            amino_acids_before_variant):
+        ReferenceSequenceKey.__init__(
+            self=self,
+            strand=strand,
+            sequence_before_variant_locus=sequence_before_variant_locus,
+            sequence_at_variant_locus=sequence_at_variant_locus,
+            sequence_after_variant_locus=sequence_after_variant_locus)
+        self.offset_to_first_complete_codon = offset_to_first_complete_codon
+        self.overlaps_start_codon = overlaps_start_codon
+        self.contains_start_codon = contains_start_codon
+        self.contains_five_prime_utr = contains_five_prime_utr
+        self.amino_acids_before_variant = amino_acids_before_variant
+
+    def __str__(self):
+        return (
+            "ReferenceCodingSequenceKey("
+            "strand='%s', "
+            "sequence_before_variant_locus='%s', "
+            "sequence_at_variant_locus='%s', "
+            "sequence_after_variant_locus='%s', "
+            "offset_to_first_complete_codon=%d, "
+            "contains_start_codon=%s, "
+            "overlaps_start_codon=%s, "
+            "contains_five_prime_utr=%s, "
+            "amino_acids_before_variant=%s)") % self._values()
+
     @classmethod
-    def from_variant_and_transcript(
-            cls,
-            variant,
-            transcript,
-            context_size):
+    def from_variant_and_transcript_and_sequence_key(
+            cls, variant, transcript, sequence_key):
         """
-        Extracts the reference sequence around a variant locus on a particular
-        transcript and determines the reading frame at the start of that
-        sequence context.
-
-        Parameters
-        ----------
-        variant : varcode.Variant
-
-        transcript : pyensembl.Transcript
-
-        context_size : int
-
-        Returns SequenceKeyWithReadingFrame object or None if Transcript lacks
-        coding sequence, protein sequence or annotated start/stop codons.
+        Assuming that the transcript has a coding sequence, take a
+        ReferenceSequenceKey (region of the transcript around the variant) and
+        return a ReferenceCodingSequenceKey (or None).
         """
-        if not transcript.contains_start_codon:
-            logger.info(
-                "Expected transcript %s for variant %s to have start codon",
-                transcript,
-                variant)
-            return None
-
-        if not transcript.contains_stop_codon:
-            logger.info(
-                "Expected transcript %s for variant %s to have stop codon",
-                transcript,
-                variant)
-            return None
-
-        if not transcript.protein_sequence:
-            logger.info(
-                "Expected transript %s for variant %s to have protein sequence",
-                transcript,
-                variant)
-            return None
-
-        sequence_key = ReferenceSequenceKey.from_variant_and_transcript(
-            variant=variant,
-            transcript=transcript,
-            context_size=context_size)
-
-        if sequence_key is None:
-            logger.info(
-                "No sequence key for variant %s on transcript %s",
-                variant,
-                transcript)
-            return None
-
         # get the interbase range of offsets which capture all reference
         # bases modified by the variant
         variant_start_offset, variant_end_offset = \
@@ -158,6 +146,7 @@ class ReferenceCodingSequenceKey(
             amino_acids_before_variant = transcript.protein_sequence[
                 n_full_codons_before_variant - n_codons_in_prefix:
                 n_full_codons_before_variant]
+
         return cls(
             strand=sequence_key.strand,
             sequence_before_variant_locus=sequence_key.sequence_before_variant_locus,
@@ -168,6 +157,66 @@ class ReferenceCodingSequenceKey(
             overlaps_start_codon=overlaps_start_codon,
             contains_five_prime_utr=contains_five_prime_utr,
             amino_acids_before_variant=amino_acids_before_variant)
+
+    @classmethod
+    def from_variant_and_transcript(
+            cls,
+            variant,
+            transcript,
+            context_size):
+        """
+        Extracts the reference sequence around a variant locus on a particular
+        transcript and determines the reading frame at the start of that
+        sequence context.
+
+        Parameters
+        ----------
+        variant : varcode.Variant
+
+        transcript : pyensembl.Transcript
+
+        context_size : int
+
+        Returns SequenceKeyWithReadingFrame object or None if Transcript lacks
+        coding sequence, protein sequence or annotated start/stop codons.
+        """
+        if not transcript.contains_start_codon:
+            logger.info(
+                "Expected transcript %s for variant %s to have start codon",
+                transcript,
+                variant)
+            return None
+
+        if not transcript.contains_stop_codon:
+            logger.info(
+                "Expected transcript %s for variant %s to have stop codon",
+                transcript,
+                variant)
+            return None
+
+        if not transcript.protein_sequence:
+            logger.info(
+                "Expected transript %s for variant %s to have protein sequence",
+                transcript,
+                variant)
+            return None
+
+        sequence_key = ReferenceSequenceKey.from_variant_and_transcript(
+            variant=variant,
+            transcript=transcript,
+            context_size=context_size)
+
+        if sequence_key is None:
+            logger.info(
+                "No sequence key for variant %s on transcript %s",
+                variant,
+                transcript)
+            return None
+
+        return cls.from_variant_and_transcript_and_sequence_key(
+            variant=variant,
+            transcript=transcript,
+            sequence_key=sequence_key)
 
 
 def reading_frame_to_offset(reading_frame_at_start_of_sequence):

--- a/isovar/reference_coding_sequence_key.py
+++ b/isovar/reference_coding_sequence_key.py
@@ -105,7 +105,7 @@ class ReferenceCodingSequenceKey(ReferenceSequenceKey):
         if variant_start_offset < start_codon_idx + 3:
             logger.info(
                 "Skipping transcript %s for variant %s, must be after start codon",
-                transcript,
+                transcript.name,
                 variant)
             return None
 

--- a/isovar/reference_context.py
+++ b/isovar/reference_context.py
@@ -83,7 +83,7 @@ class ReferenceContext(ReferenceCodingSequenceKey):
 
     @classmethod
     def from_reference_coding_sequence_key(cls, key, variant, transcripts):
-        return cls(
+        return ReferenceContext(
             strand=key.strand,
             sequence_before_variant_locus=key.sequence_before_variant_locus,
             sequence_at_variant_locus=key.sequence_at_variant_locus,

--- a/isovar/reference_context.py
+++ b/isovar/reference_context.py
@@ -35,7 +35,6 @@ logger = logging.getLogger(__name__)
 ##########################
 
 class ReferenceContext(ReferenceCodingSequenceKey):
-
     # additional fields on top of slots for ReferenceCodingSequenceKey
     __slots__ = ["variant", "transcripts"]
 
@@ -53,7 +52,7 @@ class ReferenceContext(ReferenceCodingSequenceKey):
             variant,
             transcripts):
         ReferenceCodingSequenceKey.__init__(
-            self=self,
+            self,
             strand=strand,
             sequence_before_variant_locus=sequence_before_variant_locus,
             sequence_at_variant_locus=sequence_at_variant_locus,

--- a/isovar/reference_context.py
+++ b/isovar/reference_context.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-from collections import namedtuple, OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict
 import logging
 
 from .effect_prediction import reference_transcripts_for_variant
@@ -34,9 +34,52 @@ logger = logging.getLogger(__name__)
 #
 ##########################
 
-class ReferenceContext(namedtuple(
-        "ReferenceContext",
-        ReferenceCodingSequenceKey._fields + ("variant", "transcripts"))):
+class ReferenceContext(ReferenceCodingSequenceKey):
+
+    # additional fields on top of slots for ReferenceCodingSequenceKey
+    __slots__ = ["variant", "transcripts"]
+
+    def __init__(
+            self,
+            strand,
+            sequence_before_variant_locus,
+            sequence_at_variant_locus,
+            sequence_after_variant_locus,
+            offset_to_first_complete_codon,
+            contains_start_codon,
+            overlaps_start_codon,
+            contains_five_prime_utr,
+            amino_acids_before_variant,
+            variant,
+            transcripts):
+        ReferenceCodingSequenceKey.__init__(
+            self=self,
+            strand=strand,
+            sequence_before_variant_locus=sequence_before_variant_locus,
+            sequence_at_variant_locus=sequence_at_variant_locus,
+            sequence_after_variant_locus=sequence_after_variant_locus,
+            offset_to_first_complete_codon=offset_to_first_complete_codon,
+            contains_start_codon=contains_start_codon,
+            overlaps_start_codon=overlaps_start_codon,
+            contains_five_prime_utr=contains_five_prime_utr,
+            amino_acids_before_variant=amino_acids_before_variant)
+        self.variant = variant
+        self.transcripts = tuple(transcripts)
+
+    def __str__(self):
+        return (
+            "ReferenceContext("
+            "strand='%s', "
+            "sequence_before_variant_locus='%s',"
+            "sequence_at_variant_locus=%s, "
+            "sequence_after_variant_locus=%s, "
+            "offset_to_first_complete_codon=%d, "
+            "contains_start_codon=%s, "
+            "overlaps_start_codon=%s, "
+            "contains_five_prime_utr=%s, "
+            "amino_acids_before_variant='%s', "
+            "variant=%s, "
+            "transcripts=%s)") % self._values()
 
     @classmethod
     def from_reference_coding_sequence_key(cls, key, variant, transcripts):
@@ -165,6 +208,7 @@ def variants_to_reference_contexts_dataframe(
 
     df_builder = DataFrameBuilder(
         ReferenceContext,
+        field_names=ReferenceContext._fields(),
         exclude=["variant"],
         converters=dict(transcripts=lambda ts: ";".join(t.name for t in ts)),
         extra_column_fns={

--- a/isovar/reference_context.py
+++ b/isovar/reference_context.py
@@ -66,21 +66,6 @@ class ReferenceContext(ReferenceCodingSequenceKey):
         self.variant = variant
         self.transcripts = tuple(transcripts)
 
-    def __str__(self):
-        return (
-            "ReferenceContext("
-            "strand='%s', "
-            "sequence_before_variant_locus='%s',"
-            "sequence_at_variant_locus=%s, "
-            "sequence_after_variant_locus=%s, "
-            "offset_to_first_complete_codon=%d, "
-            "contains_start_codon=%s, "
-            "overlaps_start_codon=%s, "
-            "contains_five_prime_utr=%s, "
-            "amino_acids_before_variant='%s', "
-            "variant=%s, "
-            "transcripts=%s)") % self._values()
-
     @classmethod
     def from_reference_coding_sequence_key(cls, key, variant, transcripts):
         return ReferenceContext(
@@ -208,7 +193,6 @@ def variants_to_reference_contexts_dataframe(
 
     df_builder = DataFrameBuilder(
         ReferenceContext,
-        field_names=ReferenceContext._fields(),
         exclude=["variant"],
         converters=dict(transcripts=lambda ts: ";".join(t.name for t in ts)),
         extra_column_fns={

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -129,9 +129,6 @@ class ReferenceSequenceKey(CompactObject):
             sequence_at_variant_locus=reference_cdna_at_variant,
             sequence_after_variant_locus=reference_cdna_after_variant)
 
-    def __len__(self):
-        return len(self.sequence)
-
 
 def variant_matches_reference_sequence(variant, ref_seq_on_transcript, strand):
     """

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -26,7 +26,6 @@ class ReferenceSequenceKey(CompactObject):
     Used to identify and group the distinct sequences occurring on a set of
     transcripts overlapping a variant locus.
     """
-
     __slots__ = [
         "strand",
         "sequence_before_variant_locus",

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -16,7 +16,7 @@ from __future__ import print_function, division, absolute_import
 import logging
 
 from .compact_object import CompactObject
-from .common import reverse_complement_dna
+from .dna import reverse_complement_dna
 from .variant_helpers import interbase_range_affected_by_variant_on_transcript
 
 logger = logging.getLogger(__name__)

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -129,14 +129,6 @@ class ReferenceSequenceKey(CompactObject):
             sequence_at_variant_locus=reference_cdna_at_variant,
             sequence_after_variant_locus=reference_cdna_after_variant)
 
-    def __str__(self):
-        return (
-            "ReferenceSequenceKey("
-            "strand='%s', "
-            "sequence_before_variant_locus='%s', "
-            "sequence_at_variant_locus='%s', "
-            "sequence_after_variant_locus='%s')") % self._values()
-
     @property
     def base0_variant_start_offset(self):
         return len(self.sequence_before_variant_locus)

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -129,21 +129,6 @@ class ReferenceSequenceKey(CompactObject):
             sequence_at_variant_locus=reference_cdna_at_variant,
             sequence_after_variant_locus=reference_cdna_after_variant)
 
-    @property
-    def base0_variant_start_offset(self):
-        return len(self.sequence_before_variant_locus)
-
-    @property
-    def base0_variant_end_offset(self):
-        return self.base0_variant_start_offset + len(self.sequence_at_variant_locus)
-
-    @property
-    def sequence(self):
-        return (
-            self.sequence_before_variant_locus +
-            self.sequence_at_variant_locus +
-            self.sequence_after_variant_locus)
-
     def __len__(self):
         return len(self.sequence)
 

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -72,7 +72,7 @@ class ReferenceSequenceKey(CompactObject):
         if full_transcript_sequence is None:
             logger.warn(
                 "Expected transcript %s (overlapping %s) to have sequence",
-                transcript,
+                transcript.name,
                 variant)
             return None
 
@@ -110,7 +110,7 @@ class ReferenceSequenceKey(CompactObject):
 
         logger.info(
             "Interbase offset range on %s for variant %s = %d:%d",
-            transcript,
+            transcript.name,
             variant,
             variant_start_offset,
             variant_end_offset)

--- a/isovar/string_helpers.py
+++ b/isovar/string_helpers.py
@@ -30,15 +30,15 @@ def trim_N_nucleotides(prefix, suffix):
         rightmost_index = prefix.rfind('N')
         logger.debug(
             "Trimming %d nucleotides from read prefix '%s'",
-                rightmost_index + 1, prefix)
+            rightmost_index + 1, prefix)
         prefix = prefix[rightmost_index + 1:]
 
     if 'N' in suffix:
         leftmost_index = suffix.find('N')
         logger.debug(
             "Trimming %d nucleotides from read suffix '%s'",
-                len(suffix) - leftmost_index,
-                suffix)
+            len(suffix) - leftmost_index,
+            suffix)
         suffix = suffix[:leftmost_index]
 
     return prefix, suffix

--- a/isovar/translation.py
+++ b/isovar/translation.py
@@ -153,19 +153,33 @@ class Translation(object):
         given threshold.
         """
 
-        variant_sequence_in_reading_frame = \
-            VariantSequenceInReadingFrame.from_variant_sequence_and_reference_context(
-                variant_sequence=variant_sequence,
-                reference_context=reference_context)
+        original_variant_sequence = variant_sequence
+        variant_sequence_in_reading_frame = None
+        # if we can't get the variant sequence to match this reference
+        # context then keep trimming it by coverage until either
+        while variant_sequence_in_reading_frame is None and len(variant_sequence) > 0:
+            variant_sequence_in_reading_frame = \
+                VariantSequenceInReadingFrame.from_variant_sequence_and_reference_context(
+                    variant_sequence=variant_sequence,
+                    reference_context=reference_context)
+            n_mismatch_before_variant = variant_sequence_in_reading_frame.number_mismatches
 
-        n_mismatch_before_variant = variant_sequence_in_reading_frame.number_mismatches
+            if n_mismatch_before_variant > max_transcript_mismatches:
+                logger.info(
+                    ("Too many mismatches (%d) between variant sequence %s and "
+                     "reference context %s"),
+                    n_mismatch_before_variant,
+                    reference_context,
+                    variant_sequence)
+                # if portions of the sequence are supported by only 1 read
+                # then try trimming to 2 to see if the better supported
+                # subsequence can be better matched against the reference
+                variant_sequence = variant_sequence.trim_by_coverage(
+                    variant_sequence.min_coverage() + 1)
 
-        if n_mismatch_before_variant > max_transcript_mismatches:
-            logger.info(
-                "Skipping reference context %s for %s, too many mismatching bases (%d)",
-                reference_context,
-                variant_sequence,
-                n_mismatch_before_variant)
+        if variant_sequence_in_reading_frame is None:
+            logger.info("Failed to find reading frame for %s" % (
+                original_variant_sequence,))
             return None
 
         cdna_sequence = variant_sequence_in_reading_frame.cdna_sequence

--- a/isovar/translation.py
+++ b/isovar/translation.py
@@ -165,7 +165,7 @@ class Translation(object):
             Truncate protein to be at most this long
 
         Returns either a ProteinSequence object or None if the number of
-        mismatches between the RNA and reference transcript sequences exceeds the
+        mismatches between the RNA and reference transcript sequences exceeds
         given threshold.
         """
 
@@ -174,6 +174,10 @@ class Translation(object):
             reference_context,
             min_transcript_prefix_length=min_transcript_prefix_length,
             max_transcript_mismatches=max_transcript_mismatches)
+
+        if variant_sequence_in_reading_frame is None:
+            logger.info("Unable to determine reading frame for %s", variant_sequence)
+            return None
 
         cdna_sequence = variant_sequence_in_reading_frame.cdna_sequence
         cdna_codon_offset = variant_sequence_in_reading_frame.offset_to_first_complete_codon

--- a/isovar/translation.py
+++ b/isovar/translation.py
@@ -76,6 +76,8 @@ class Translation(object):
             untrimmed_variant_sequence,
             reference_context,
             variant_sequence_in_reading_frame):
+        # TODO: get rid of untrimmed_variant_sequence by making
+        # VariantSequenceInReadingFrame keep track of its inputs
         self.amino_acids = amino_acids
         self.variant_aa_interval_start = variant_aa_interval_start
         self.variant_aa_interval_end = variant_aa_interval_end
@@ -168,7 +170,6 @@ class Translation(object):
         mismatches between the RNA and reference transcript sequences exceeds
         given threshold.
         """
-
         variant_sequence_in_reading_frame = match_variant_sequence_to_reference_context(
             variant_sequence,
             reference_context,

--- a/isovar/variant_sequence_in_reading_frame.py
+++ b/isovar/variant_sequence_in_reading_frame.py
@@ -221,7 +221,7 @@ def match_variant_sequence_to_reference_context(
         reference_context,
         min_transcript_prefix_length,
         max_transcript_mismatches,
-        max_attempts=5):
+        max_attempts=3):
     """
     Iteratively trim low-coverage subsequences of a variant sequence
     until it either matches the given reference context or there

--- a/isovar/variant_sequence_in_reading_frame.py
+++ b/isovar/variant_sequence_in_reading_frame.py
@@ -246,6 +246,8 @@ def match_variant_sequence_to_reference_context(
     # if we can't get the variant sequence to match this reference
     # context then keep trimming it by coverage until either
     while (variant_sequence_in_reading_frame is None and
+            # TODO: check the reverse-complemented prefix if it's on the
+            # negative strand
             len(variant_sequence.prefix) >= min_transcript_prefix_length and
             attempt < max_attempts):
 

--- a/isovar/variant_sequence_in_reading_frame.py
+++ b/isovar/variant_sequence_in_reading_frame.py
@@ -242,14 +242,24 @@ def match_variant_sequence_to_reference_context(
 
     variant_sequence_in_reading_frame = None
     attempt = 0
-
     # if we can't get the variant sequence to match this reference
     # context then keep trimming it by coverage until either
-    while (variant_sequence_in_reading_frame is None and
-            # TODO: check the reverse-complemented prefix if it's on the
-            # negative strand
-            len(variant_sequence.prefix) >= min_transcript_prefix_length and
-            attempt < max_attempts):
+    while variant_sequence_in_reading_frame is None and attempt < max_attempts:
+
+        # check the reverse-complemented prefix if the reference context is
+        # on the negative strand
+        variant_sequence_too_short = (
+            (reference_context.strand == "+" and
+                len(variant_sequence.prefix) < min_transcript_prefix_length) or
+            (reference_context.strand == "-" and
+                len(variant_sequence.suffix) < min_transcript_prefix_length)
+        )
+        if variant_sequence_too_short:
+            logger.info(
+                "Skipping variant sequence %s because too few nucleotides before variant (min %d)",
+                variant_sequence,
+                min_transcript_prefix_length)
+            break
 
         variant_sequence_in_reading_frame = \
             VariantSequenceInReadingFrame.from_variant_sequence_and_reference_context(

--- a/isovar/variant_sequence_in_reading_frame.py
+++ b/isovar/variant_sequence_in_reading_frame.py
@@ -22,7 +22,7 @@ from __future__ import print_function, division, absolute_import
 from collections import namedtuple
 import logging
 
-from six.moves import range
+from six.moves import range, zip
 
 from .dna import reverse_complement_dna
 
@@ -268,36 +268,38 @@ def match_variant_sequence_to_reference_context(
                 variant_sequence=variant_sequence,
                 reference_context=reference_context)
 
-        if variant_sequence_in_reading_frame is not None:
-            n_mismatch_before_variant = (
-                variant_sequence_in_reading_frame.number_mismatches)
-            logger.info("Attempt #%d/%d: %s" % (
-                attempt + 1, max_attempts, variant_sequence_in_reading_frame))
-            if n_mismatch_before_variant <= max_transcript_mismatches:
-                # if we got a variant sequence + reading frame with sufficiently
-                # few mismatches then call it a day
-                return variant_sequence_in_reading_frame
-            else:
-                logger.info(
-                    ("Too many mismatches (%d) between variant sequence %s and "
-                     "reference context %s (attempt=%d/%d)"),
-                    n_mismatch_before_variant,
-                    variant_sequence,
-                    reference_context,
-                    attempt + 1,
-                    max_attempts)
-                # abandon the VariantSequenceInReadingFrame we've gotten
-                # so far in favor of hopefully one with fewer mismatches
-                # after trimming
-                variant_sequence_in_reading_frame = None
+        if variant_sequence_in_reading_frame is None:
+            return None
 
-                # if portions of the sequence are supported by only 1 read
-                # then try trimming to 2 to see if the better supported
-                # subsequence can be better matched against the reference
-                current_min_coverage = variant_sequence.min_coverage()
-                logger.info(
-                    "Trimming to subsequence covered by at least %d reads",
-                    current_min_coverage + 1)
-                variant_sequence = variant_sequence.trim_by_coverage(
-                    current_min_coverage + 1)
+        n_mismatch_before_variant = (
+            variant_sequence_in_reading_frame.number_mismatches)
+        logger.info("Attempt #%d/%d: %s" % (
+            attempt + 1, max_attempts, variant_sequence_in_reading_frame))
+        if n_mismatch_before_variant <= max_transcript_mismatches:
+            # if we got a variant sequence + reading frame with sufficiently
+            # few mismatches then call it a day
+            return variant_sequence_in_reading_frame
+        else:
+            logger.info(
+                ("Too many mismatches (%d) between variant sequence %s and "
+                 "reference context %s (attempt=%d/%d)"),
+                n_mismatch_before_variant,
+                variant_sequence,
+                reference_context,
+                attempt + 1,
+                max_attempts)
+            # abandon the VariantSequenceInReadingFrame we've gotten
+            # so far in favor of hopefully one with fewer mismatches
+            # after trimming
+            variant_sequence_in_reading_frame = None
+
+            # if portions of the sequence are supported by only 1 read
+            # then try trimming to 2 to see if the better supported
+            # subsequence can be better matched against the reference
+            current_min_coverage = variant_sequence.min_coverage()
+            logger.info(
+                "Trimming to subsequence covered by at least %d reads",
+                current_min_coverage + 1)
+            variant_sequence = variant_sequence.trim_by_coverage(
+                current_min_coverage + 1)
     return variant_sequence_in_reading_frame

--- a/isovar/variant_sequence_in_reading_frame.py
+++ b/isovar/variant_sequence_in_reading_frame.py
@@ -22,7 +22,7 @@ from __future__ import print_function, division, absolute_import
 from collections import namedtuple
 import logging
 
-from .common import reverse_complement_dna
+from .dna import reverse_complement_dna
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +132,7 @@ def trim_sequences(variant_sequence, reference_context):
     # if the transcript is on the reverse strand then we have to
     # take the sequence PREFIX|VARIANT|SUFFIX
     # and take the complement of XIFFUS|TNAIRAV|XIFERP
-    if False and reference_context.strand == "-":
+    if reference_context.strand == "-":
         # notice that we are setting the *prefix* to be reverse complement
         # of the *suffix* and vice versa
         cdna_prefix, cdna_alt, cdna_suffix = (

--- a/isovar/variant_sequence_in_reading_frame.py
+++ b/isovar/variant_sequence_in_reading_frame.py
@@ -62,6 +62,15 @@ class VariantSequenceInReadingFrame(namedtuple("VariantSequenceInReadingFrame", 
         cdna_prefix, cdna_alt, cdna_suffix, reference_prefix, n_trimmed_from_reference = \
             trim_sequences(variant_sequence, reference_context)
 
+        logger.info(
+            ("cdna_predix='%s', cdna_alt='%s', cdna_suffix='%s', "
+             "reference_prefix='%s', n_trimmed=%d"),
+            cdna_prefix,
+            cdna_alt,
+            cdna_suffix,
+            reference_prefix,
+            n_trimmed_from_reference)
+
         n_mismatch_before_variant = count_mismatches(reference_prefix, cdna_prefix)
 
         ref_codon_offset = reference_context.offset_to_first_complete_codon
@@ -74,7 +83,7 @@ class VariantSequenceInReadingFrame(namedtuple("VariantSequenceInReadingFrame", 
             n_trimmed_from_reference_sequence=n_trimmed_from_reference)
 
         cdna_sequence = cdna_prefix + cdna_alt + cdna_suffix
-        variant_interval_start = len(cdna_prefix) + 1
+        variant_interval_start = len(cdna_prefix)
         variant_interval_end = variant_interval_start + len(cdna_alt)
 
         return VariantSequenceInReadingFrame(
@@ -123,7 +132,7 @@ def trim_sequences(variant_sequence, reference_context):
     # if the transcript is on the reverse strand then we have to
     # take the sequence PREFIX|VARIANT|SUFFIX
     # and take the complement of XIFFUS|TNAIRAV|XIFERP
-    if reference_context.strand == "-":
+    if False and reference_context.strand == "-":
         # notice that we are setting the *prefix* to be reverse complement
         # of the *suffix* and vice versa
         cdna_prefix, cdna_alt, cdna_suffix = (
@@ -255,8 +264,8 @@ def match_variant_sequence_to_reference_context(
                     ("Too many mismatches (%d) between variant sequence %s and "
                      "reference context %s"),
                     n_mismatch_before_variant,
-                    reference_context,
-                    variant_sequence)
+                    variant_sequence,
+                    reference_context)
 
                 variant_sequence_in_reading_frame = None
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
             'pysam >= 0.9.0',
             'pandas',
             'varcode>=0.5.9',
-            'pyensembl>=1.0.3'
+            'pyensembl>=1.0.3',
         ],
         long_description=readme,
         packages=find_packages(),

--- a/test/test_protein_sequences.py
+++ b/test/test_protein_sequences.py
@@ -66,7 +66,7 @@ def make_dummy_translation(
         variant_aa_interval_end=variant_aa_interval_end,
         frameshift=False,
         ends_with_stop_codon=False,
-        variant_sequence=None,
+        untrimmed_variant_sequence=None,
         reference_context=None)
 
 def make_dummy_protein_sequence(

--- a/test/test_read_helpers.py
+++ b/test/test_read_helpers.py
@@ -47,6 +47,3 @@ def test_group_unique_sequences():
     # there are some redundant reads, so we expect that the number of
     # unique entries should be less than the total read partitions
     assert len(variant_reads) > len(groups)
-
-if __name__ == "__main__":
-    test_group_unique_sequences()

--- a/test/test_reference_coding_sequence_key.py
+++ b/test/test_reference_coding_sequence_key.py
@@ -22,7 +22,6 @@ from varcode import Variant
 from pyensembl import ensembl_grch38
 from nose.tools import eq_
 
-from testing_helpers import assert_equal_fields
 
 def test_reading_frame_to_offset():
     eq_(reading_frame_to_offset(0), 0)
@@ -64,7 +63,7 @@ def test_sequence_key_with_reading_frame_substitution_with_five_prime_utr():
         overlaps_start_codon=True,
         contains_five_prime_utr=True,
         amino_acids_before_variant="M")
-    assert_equal_fields(result, expected)
+    eq_(result, expected)
 
 def test_sequence_key_with_reading_frame_deletion_with_five_prime_utr():
     # Delete second codon of TP53-001, the surrounding context
@@ -101,7 +100,7 @@ def test_sequence_key_with_reading_frame_deletion_with_five_prime_utr():
         overlaps_start_codon=True,
         contains_five_prime_utr=True,
         amino_acids_before_variant="M")
-    assert_equal_fields(result, expected)
+    eq_(result, expected)
 
 
 def test_sequence_key_with_reading_frame_insertion():
@@ -139,7 +138,7 @@ def test_sequence_key_with_reading_frame_insertion():
         overlaps_start_codon=True,
         contains_five_prime_utr=True,
         amino_acids_before_variant="ME")
-    assert_equal_fields(result, expected)
+    eq_(result, expected)
 
 def test_reference_coding_sequence_key_insertion_inside_start_codon():
     # insert nucleotide "C" in the middle of the start codon of TP53-001,
@@ -201,7 +200,7 @@ def test_sequence_key_with_reading_frame_insertion_context_6nt_contains_start():
         overlaps_start_codon=True,
         contains_five_prime_utr=False,
         amino_acids_before_variant="ME")
-    assert_equal_fields(result, expected)
+    eq_(result, expected)
 
 
 def test_sequence_key_with_reading_frame_insertion_context_5nt_overlaps_start():
@@ -237,7 +236,7 @@ def test_sequence_key_with_reading_frame_insertion_context_5nt_overlaps_start():
         overlaps_start_codon=True,
         contains_five_prime_utr=False,
         amino_acids_before_variant="E")
-    assert_equal_fields(result, expected)
+    eq_(result, expected)
 
 
 def test_sequence_key_with_reading_frame_insertion_context_3nt_no_start():
@@ -271,4 +270,59 @@ def test_sequence_key_with_reading_frame_insertion_context_3nt_no_start():
         overlaps_start_codon=False,
         contains_five_prime_utr=False,
         amino_acids_before_variant="E")
-    assert_equal_fields(result, expected)
+    eq_(result, expected)
+
+
+def test_reference_sequence_key_hash_and_equality_same_objects():
+    rcsk1 = ReferenceCodingSequenceKey(
+        strand="-",
+        sequence_before_variant_locus="GAG",
+        sequence_at_variant_locus="",
+        sequence_after_variant_locus="GAG",
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="E")
+    rcsk2 = ReferenceCodingSequenceKey(
+        strand="-",
+        sequence_before_variant_locus="GAG",
+        sequence_at_variant_locus="",
+        sequence_after_variant_locus="GAG",
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="E")
+
+    eq_(rcsk1, rcsk2)
+    eq_(str(rcsk1), str(rcsk2))
+    eq_(repr(rcsk1), repr(rcsk2))
+    eq_(hash(rcsk1), hash(rcsk2))
+
+def test_reference_sequence_key_hash_and_equality_different_objects():
+    rcsk1 = ReferenceCodingSequenceKey(
+        strand="-",
+        sequence_before_variant_locus="GAG",
+        sequence_at_variant_locus="",
+        sequence_after_variant_locus="GAG",
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="E")
+    rcsk_different_strand = ReferenceCodingSequenceKey(
+        strand="+",
+        sequence_before_variant_locus="GAG",
+        sequence_at_variant_locus="",
+        sequence_after_variant_locus="GAG",
+        offset_to_first_complete_codon=0,
+        contains_start_codon=False,
+        overlaps_start_codon=False,
+        contains_five_prime_utr=False,
+        amino_acids_before_variant="E")
+
+    assert rcsk1 != rcsk_different_strand
+    assert str(rcsk1) != str(rcsk_different_strand)
+    assert repr(rcsk1) != repr(rcsk_different_strand)
+    assert hash(rcsk1) != hash(rcsk_different_strand)

--- a/test/test_reference_contexts.py
+++ b/test/test_reference_contexts.py
@@ -23,7 +23,7 @@ from varcode import Variant, VariantCollection
 from pyensembl import ensembl_grch38
 from nose.tools import eq_
 
-from testing_helpers import assert_equal_fields, load_vcf
+from testing_helpers import load_vcf
 
 def test_sequence_key_with_reading_frame_substitution_on_negative_strand():
     # replace second codon of TP53-001 with 'CCC'
@@ -94,7 +94,7 @@ def test_sequence_key_with_reading_frame_substitution_on_negative_strand():
         amino_acids_before_variant="M",
         variant=tp53_substitution,
         transcripts=[tp53_001])
-    assert_equal_fields(result, expected)
+    eq_(result, expected)
 
 def test_variants_to_reference_contexts_dataframe():
     variants = load_vcf("data/b16.f10/b16.vcf")
@@ -107,6 +107,76 @@ def test_variants_to_reference_contexts_dataframe():
     eq_(len(groups), len(variants))
 
 
-if __name__ == "__main__":
-    test_sequence_key_with_reading_frame_substitution_on_negative_strand()
-    test_variants_to_reference_contexts_dataframe()
+def test_reference_context_hash_and_equality_same_object():
+    rc1 = ReferenceContext(
+        strand="-",
+        sequence_before_variant_locus="C" * 7 + "ATG",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="TT",
+        offset_to_first_complete_codon=7,
+        contains_start_codon=True,
+        overlaps_start_codon=True,
+        contains_five_prime_utr=True,
+        amino_acids_before_variant="M",
+        variant=None,
+        transcripts=[])
+    rc2 = ReferenceContext(
+        strand="-",
+        sequence_before_variant_locus="C" * 7 + "ATG",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="TT",
+        offset_to_first_complete_codon=7,
+        contains_start_codon=True,
+        overlaps_start_codon=True,
+        contains_five_prime_utr=True,
+        amino_acids_before_variant="M",
+        variant=None,
+        transcripts=[])
+
+    eq_(rc1, rc2)
+    eq_(str(rc1), str(rc2))
+    eq_(repr(rc1), repr(rc2))
+    eq_(hash(rc1), hash(rc2))
+
+def test_reference_context_hash_and_equality_different_objects():
+    rc1 = ReferenceContext(
+        strand="-",
+        sequence_before_variant_locus="C" * 7 + "ATG",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="TT",
+        offset_to_first_complete_codon=7,
+        contains_start_codon=True,
+        overlaps_start_codon=True,
+        contains_five_prime_utr=True,
+        amino_acids_before_variant="M",
+        variant=None,
+        transcripts=[])
+
+    rc_different_strand = ReferenceContext(
+        strand="+",
+        sequence_before_variant_locus="C" * 7 + "ATG",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="TT",
+        offset_to_first_complete_codon=7,
+        contains_start_codon=True,
+        overlaps_start_codon=True,
+        contains_five_prime_utr=True,
+        amino_acids_before_variant="M",
+        variant=None,
+        transcripts=[])
+
+    assert rc1 != rc_different_strand, \
+        "Expected %s != %s" % (rc1, rc_different_strand)
+    assert str(rc1) != str(rc_different_strand), \
+        "Expected __str__ '%s' != '%s'" % (
+            rc1, rc_different_strand)
+    assert repr(rc1) != repr(rc_different_strand), \
+        "Expected __repr__ '%s' != '%s'" % (
+            rc1, rc_different_strand)
+
+    assert hash(rc1) != hash(rc_different_strand), \
+        "Expected hash(%s) != hash(%s) (%d vs. %d)" % (
+            rc1,
+            rc_different_strand,
+            hash(rc1),
+            hash(rc_different_strand))

--- a/test/test_reference_sequence_key.py
+++ b/test/test_reference_sequence_key.py
@@ -19,7 +19,6 @@ from varcode import Variant
 from pyensembl import ensembl_grch38
 from nose.tools import eq_
 
-from testing_helpers import assert_equal_fields
 
 def test_sequence_key_for_variant_on_transcript_substitution():
     # rs769125639 is a simple T>A substitution in the 6th nucleotide of
@@ -42,7 +41,7 @@ def test_sequence_key_for_variant_on_transcript_substitution():
         sequence_before_variant_locus=brca2_ref_seq[:5],
         sequence_at_variant_locus="T",
         sequence_after_variant_locus=brca2_ref_seq[6:16])
-    assert_equal_fields(sequence_key, expected_sequence_key)
+    eq_(sequence_key, expected_sequence_key)
 
 
 def test_sequence_key_for_variant_on_transcript_deletion():
@@ -65,7 +64,7 @@ def test_sequence_key_for_variant_on_transcript_deletion():
         sequence_before_variant_locus=brca2_ref_seq[:5],
         sequence_at_variant_locus="T",
         sequence_after_variant_locus=brca2_ref_seq[6:16])
-    assert_equal_fields(sequence_key, expected_sequence_key)
+    eq_(sequence_key, expected_sequence_key)
 
 def test_sequence_key_for_variant_on_transcript_insertion():
     # Insert 'CCC' after the 6th nucleotide of BRCA2-001's 5' UTR
@@ -90,7 +89,7 @@ def test_sequence_key_for_variant_on_transcript_insertion():
         sequence_before_variant_locus=brca2_ref_seq[:6],
         sequence_at_variant_locus="",
         sequence_after_variant_locus=brca2_ref_seq[6:16])
-    assert_equal_fields(sequence_key, expected_sequence_key)
+    eq_(sequence_key, expected_sequence_key)
 
 
 def test_sequence_key_for_variant_on_transcript_substitution_reverse_strand():
@@ -115,7 +114,7 @@ def test_sequence_key_for_variant_on_transcript_substitution_reverse_strand():
         sequence_before_variant_locus="GGTCACTGCC",
         sequence_at_variant_locus="ATG",
         sequence_after_variant_locus="GAGGAGCCGC")
-    assert_equal_fields(sequence_key, expected_sequence_key)
+    eq_(sequence_key, expected_sequence_key)
 
 def test_sequence_key_for_variant_on_transcript_deletion_reverse_strand():
     # delete start codon of TP53-001, which in reverse complement means
@@ -139,7 +138,7 @@ def test_sequence_key_for_variant_on_transcript_deletion_reverse_strand():
         sequence_before_variant_locus="GGTCACTGCC",
         sequence_at_variant_locus="ATG",
         sequence_after_variant_locus="GAGGAGCCGC")
-    assert_equal_fields(sequence_key, expected_sequence_key)
+    eq_(sequence_key, expected_sequence_key)
 
 def test_sequence_key_for_variant_on_transcript_insertion_reverse_strand():
     # insert 'CCC' after start codon of TP53-001, which on the reverse
@@ -167,4 +166,37 @@ def test_sequence_key_for_variant_on_transcript_insertion_reverse_strand():
         sequence_before_variant_locus="CACTGCCATG",
         sequence_at_variant_locus="",
         sequence_after_variant_locus="GAGGAGCCGC")
-    assert_equal_fields(sequence_key, expected_sequence_key)
+    eq_(sequence_key, expected_sequence_key)
+
+
+def test_reference_sequence_key_hash_and_equality_same_objects():
+    rsk1 = ReferenceSequenceKey(
+        strand="+",
+        sequence_before_variant_locus="AAA",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="GGG")
+    rsk2 = ReferenceSequenceKey(
+        strand="+",
+        sequence_before_variant_locus="AAA",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="GGG")
+    eq_(rsk1, rsk2)
+    eq_(hash(rsk1), hash(rsk2))
+    eq_(str(rsk1), str(rsk2))
+    eq_(repr(rsk1), repr(rsk2))
+
+def test_reference_sequence_key_hash_and_equality_different_objects():
+    rsk1 = ReferenceSequenceKey(
+        strand="+",
+        sequence_before_variant_locus="AAA",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="GGG")
+    rsk_different_strand = ReferenceSequenceKey(
+        strand="-",
+        sequence_before_variant_locus="AAA",
+        sequence_at_variant_locus="T",
+        sequence_after_variant_locus="GGG")
+    assert rsk1 != rsk_different_strand
+    assert hash(rsk1) != hash(rsk_different_strand)
+    assert str(rsk1) != str(rsk_different_strand)
+    assert repr(rsk1) != repr(rsk_different_strand)

--- a/test/test_reference_sequence_key.py
+++ b/test/test_reference_sequence_key.py
@@ -19,7 +19,6 @@ from varcode import Variant
 from pyensembl import ensembl_grch38
 from nose.tools import eq_
 
-
 def test_sequence_key_for_variant_on_transcript_substitution():
     # rs769125639 is a simple T>A substitution in the 6th nucleotide of
     # BRCA2-001's 5' UTR

--- a/test/test_variant_reads_with_dummy_samfile.py
+++ b/test/test_variant_reads_with_dummy_samfile.py
@@ -19,7 +19,7 @@ from isovar.variant_reads import reads_supporting_variant
 from isovar.allele_reads import AlleleRead
 
 from mock_read_data import DummySamFile, make_read
-from testing_helpers import assert_equal_fields
+from nose.tools import eq_
 
 def test_partitioned_read_sequences_snv():
     """
@@ -51,7 +51,7 @@ def test_partitioned_read_sequences_snv():
         prefix="ACC",
         allele="G",
         suffix="TG")
-    assert_equal_fields(variant_read, expected)
+    eq_(variant_read, expected)
 
 def test_partitioned_read_sequences_insertion():
     """
@@ -83,7 +83,7 @@ def test_partitioned_read_sequences_insertion():
         prefix="ACCT",
         allele="G",
         suffix="TG")
-    assert_equal_fields(variant_read, expected)
+    eq_(variant_read, expected)
 
 def test_partitioned_read_sequences_deletion():
     """
@@ -114,9 +114,4 @@ def test_partitioned_read_sequences_deletion():
         prefix="ACCT",
         allele="",
         suffix="G")
-    assert_equal_fields(variant_read, expected)
-
-if __name__ == "__main__":
-    test_partitioned_read_sequences_snv()
-    test_partitioned_read_sequences_insertion()
-    test_partitioned_read_sequences_deletion()
+    eq_(variant_read, expected)

--- a/test/test_variant_sequence_in_reading_frame.py
+++ b/test/test_variant_sequence_in_reading_frame.py
@@ -110,18 +110,31 @@ def make_inputs_for_tp53_201_variant(
     # variant sequence supported by two reads
     # one fully spanning the variant sequence
     # and another missing the last nucleotide
+    fully_overlapping_read = AlleleRead(
+        prefix=gdna_prefix,
+        allele=gdna_alt,
+        suffix=gdna_suffix,
+        name="full-overlap")
+    # testing the prefix and allele to make sure they have the expected
+    # TP53-201 sequence but the suffix might change depending on what's
+    # passed in as cdna_prefix
+    eq_(fully_overlapping_read.prefix, "ATCTGACTGCGGCTCCT")
+    eq_(fully_overlapping_read.allele, "T")
+
+    partially_overlapping_read = AlleleRead(
+        prefix=gdna_prefix,
+        allele=gdna_alt,
+        suffix=gdna_suffix[:-1],
+        name="partial-overlap")
+    eq_(partially_overlapping_read.prefix, "ATCTGACTGCGGCTCCT")
+    eq_(partially_overlapping_read.allele, "T")
+
     variant_sequence = VariantSequence(
         prefix=gdna_prefix,
         alt=gdna_alt,
         suffix=gdna_suffix,
-        reads=[
-            AlleleRead(
-                prefix=gdna_prefix, allele=gdna_alt, suffix=gdna_suffix,
-                name="full-overlap"),
-            AlleleRead(
-                prefix=gdna_prefix, allele=gdna_alt, suffix=gdna_suffix[:-1],
-                name="partial-overlap"),
-        ])
+        reads=[fully_overlapping_read, partially_overlapping_read])
+
     assert isinstance(variant_sequence, VariantSequence)
 
     prefix_length = len(cdna_prefix) - n_bad_nucleotides_at_start

--- a/test/test_variant_sequence_in_reading_frame.py
+++ b/test/test_variant_sequence_in_reading_frame.py
@@ -1,5 +1,9 @@
 from nose.tools import eq_
-from isovar.variant_sequence_in_reading_frame import compute_offset_to_first_complete_codon
+from isovar.variant_sequence_in_reading_frame import (
+    compute_offset_to_first_complete_codon,
+    match_variant_sequence_to_reference_context,
+    VariantSequenceInReadingFrame
+)
 
 def test_compute_offset_to_first_complete_codon_no_trimming():
     # if nothing gets trimmed from the reference sequence, then
@@ -44,3 +48,16 @@ def test_compute_offset_to_first_complete_codon_trimming_after_codon():
             offset_to_first_complete_reference_codon=7,
             n_trimmed_from_reference_sequence=10),
         0)
+
+def test_match_variant_sequence_to_reference_context_exact_match():
+    # Coding sequence = --|ATG|CCC|TAG
+    # first two nucleotides are untranslated region
+    cdna_sequence = "GGATGCCCTAG"
+    varseq_in_orf = VariantSequenceInReadingFrame(
+        cdna_sequence=cdna_sequence,
+        offset_to_first_complete_codon=2,
+        variant_cdna_interval_start=5,
+        variant_cdna_interval_end=6,
+        reference_cdna_sequence_before_variant="GGATG",
+        number_mismatches=0)
+

--- a/test/test_variant_sequence_in_reading_frame.py
+++ b/test/test_variant_sequence_in_reading_frame.py
@@ -134,7 +134,6 @@ def make_inputs_for_tp53_201_variant(
         alt=gdna_alt,
         suffix=gdna_suffix,
         reads=[fully_overlapping_read, partially_overlapping_read])
-
     assert isinstance(variant_sequence, VariantSequence)
 
     prefix_length = len(cdna_prefix) - n_bad_nucleotides_at_start
@@ -209,7 +208,7 @@ def test_match_variant_sequence_to_reference_context_trim_1_bad_nucleotide():
         reference_context=reference_context,
         min_transcript_prefix_length=3,
         max_transcript_mismatches=0,
-        max_attempts=2)
+        max_trimming_attempts=1)
     eq_(expected, result)
 
 def test_match_variant_sequence_to_reference_context_ignore_extra_prefix():
@@ -227,13 +226,13 @@ def test_match_variant_sequence_to_reference_context_ignore_extra_prefix():
         reference_context=reference_context,
         min_transcript_prefix_length=3,
         max_transcript_mismatches=0,
-        max_attempts=1)
+        max_trimming_attempts=0)
     eq_(expected, result)
     # make sure that the "GGG" codon got ignored since translation
     # should start at the "ATG" after it
     eq_(result.cdna_sequence[:3], "ATG")
 
-def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_1_attempt():
+def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_no_trimming():
     # matching should fail if no mismatches are allowed and no trimming rounds
     # are allowed
     variant_sequence, reference_context, _ = \
@@ -246,11 +245,11 @@ def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_1_atte
         reference_context=reference_context,
         min_transcript_prefix_length=2,
         max_transcript_mismatches=0,
-        max_attempts=1)
+        max_trimming_attempts=0)
     eq_(None, result)
 
 
-def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_2_attempts():
+def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_trimming():
     # match should succeed if 1 round of trimming is allowed
     variant_sequence, reference_context, expected = \
         make_inputs_for_tp53_201_variant(
@@ -261,7 +260,7 @@ def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_2_atte
         reference_context=reference_context,
         min_transcript_prefix_length=2,
         max_transcript_mismatches=0,
-        max_attempts=2)
+        max_trimming_attempts=1)
     eq_(expected, result)
 
 def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_allow_mismatch():
@@ -276,5 +275,5 @@ def test_match_variant_sequence_to_reference_context_bad_start_nucleotide_allow_
         reference_context=reference_context,
         min_transcript_prefix_length=3,
         max_transcript_mismatches=1,
-        max_attempts=1)
+        max_trimming_attempts=0)
     eq_(expected, result)

--- a/test/test_variant_sequence_in_reading_frame.py
+++ b/test/test_variant_sequence_in_reading_frame.py
@@ -1,9 +1,15 @@
 from nose.tools import eq_
+from varcode import Variant
 from isovar.variant_sequence_in_reading_frame import (
     compute_offset_to_first_complete_codon,
     match_variant_sequence_to_reference_context,
-    VariantSequenceInReadingFrame
+    VariantSequenceInReadingFrame,
 )
+from isovar.variant_sequences import VariantSequence
+from isovar.reference_coding_sequence_key import ReferenceCodingSequenceKey
+from isovar.reference_context import ReferenceContext
+from isovar.allele_reads import AlleleRead
+
 
 def test_compute_offset_to_first_complete_codon_no_trimming():
     # if nothing gets trimmed from the reference sequence, then
@@ -49,15 +55,80 @@ def test_compute_offset_to_first_complete_codon_trimming_after_codon():
             n_trimmed_from_reference_sequence=10),
         0)
 
-def test_match_variant_sequence_to_reference_context_exact_match():
-    # Coding sequence = --|ATG|CCC|TAG
-    # first two nucleotides are untranslated region
-    cdna_sequence = "GGATGCCCTAG"
-    varseq_in_orf = VariantSequenceInReadingFrame(
-        cdna_sequence=cdna_sequence,
-        offset_to_first_complete_codon=2,
-        variant_cdna_interval_start=5,
-        variant_cdna_interval_end=6,
-        reference_cdna_sequence_before_variant="GGATG",
-        number_mismatches=0)
+def make_inputs_for_tp53_201_variant(
+        context_size=3,
+        prefix=None):
+    # TP53-201 is an isoform of TP53 which seems to lack untranslated
+    # regions so the sequence is:
+    # First exon: chr17 7,676,594 - 7,676,521
+    # ATG|GAG|GAG|CCG|CAG|TCA|GAT...
+    # -M-|-E-|-E-|-P-|-Q-|-S-|-D-
 
+    # we're assuming a variant
+    # chr17. 7,676,591 C>T which changes GAG (E) > AAG (K)
+    variant = Variant("chr17", 7676591, "C", "T", "GRCh38")
+
+    # TP53-201
+    transcript = variant.ensembl.transcripts_by_name("TP53-201")[0]
+
+    effect = variant.effect_on_transcript(transcript)
+
+    eq_(effect.__class__.__name__, "Substitution")
+    eq_(effect.aa_ref, "E")
+    eq_(effect.aa_alt, "K")
+
+    prefix = "ATG" if prefix is None else prefix
+    alt = "A"
+    suffix = "AGGAGCCGCAGTCAGAT"
+    cdna_sequence = prefix + alt + suffix
+    # variant sequence supported by two reads
+    # one fully spanning the variant sequence
+    # and another missing the first and last
+    # nucleotides
+    variant_sequence = VariantSequence(
+        prefix=prefix,
+        alt=alt,
+        suffix=suffix,
+        reads=[
+            AlleleRead(
+                prefix=prefix, allele=alt, suffix=suffix,
+                name="full-overlap"),
+            AlleleRead(
+                prefix=prefix[1:], allele=alt, suffix=suffix[:-1],
+                name="partial-overlap"),
+        ])
+    assert isinstance(variant_sequence, VariantSequence)
+
+    reference_coding_sequence_key = ReferenceCodingSequenceKey.from_variant_and_transcript(
+        variant=variant,
+        transcript=transcript,
+        context_size=3)
+    assert isinstance(reference_coding_sequence_key, ReferenceCodingSequenceKey)
+
+    reference_context = ReferenceContext.from_reference_coding_sequence_key(
+        key=reference_coding_sequence_key,
+        variant=variant,
+        transcripts=[transcript])
+    assert isinstance(reference_context, ReferenceContext)
+
+    expected = VariantSequenceInReadingFrame(
+        cdna_sequence=cdna_sequence,
+        offset_to_first_complete_codon=0,
+        variant_cdna_interval_start=3,
+        variant_cdna_interval_end=4,
+        reference_cdna_sequence_before_variant="ATG",
+        number_mismatches=0)
+    assert isinstance(expected, VariantSequenceInReadingFrame)
+
+    return variant_sequence, reference_context, expected
+
+def test_match_variant_sequence_to_reference_context_exact_match():
+    variant_sequence, reference_context, expected = \
+        make_inputs_for_tp53_201_variant(context_size=3)
+
+    result = match_variant_sequence_to_reference_context(
+        variant_sequence=variant_sequence,
+        reference_context=reference_context,
+        min_transcript_prefix_length=3,
+        max_transcript_mismatches=0)
+    eq_(expected, result)


### PR DESCRIPTION
**New Functionality**

Since turning on assembly of `VariantSequence` objects by default, we now have to contend with variant sequences which are very well supported at most positions but may have a small number of leading nucleotides which came from a single read. That read may contain errors or may protrude into an intronic region -- creating mismatches relative to the reference transcripts which prevent determination of a reading frame. We deal with this by trying to trim the variant sequence to regions of increasing coverage, in the hopes that parts of the sequence spanned by many reads are more reliable and will better match the reference. 

Closes https://github.com/hammerlab/isovar/issues/58

**Refactoring**

`ReferenceContext`, `ReferenceSequenceKey`, and `ReferenceCodingSequenceKey` are no longer namedtuples but instead inherit from a `CompactObject` base class which uses a `__slots__` field to automatically implement pretty printing, equality, hashing, &c. I wanted to do away with the imitation of inheritance between namedtuples and instead make these classes have explicit `__init__` functions which fully specify all of their arguments.  

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/isovar/61)
<!-- Reviewable:end -->
