### PR TITLE
added --min-alt-rna-reads option

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -14,4 +14,4 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -109,10 +109,10 @@ def greedy_merge(
                 merged_variant_sequences[combined.sequence] = combined
             else:
                 # it's possible to get the same merged sequence from distinct
-                # input sequences
+                # values of variant_sequence2
                 # For example
-                #   abcXYZddd + cXYZdddd = abcXYZdddd
-                #   abcXYZd + bcXYZdddd =  abcXYZdddd
+                #   abcXYZddd +  cXYZdddd  = abcXYZdddd
+                #   abcXYZddd + bcXYZdddd  = abcXYZdddd
                 # In this case we make a VariantSequence record with the
                 # reads from both original sequences.
                 existing_record_with_same_sequence = merged_variant_sequences[

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -49,7 +49,7 @@ def sort_by_decreasing_total_length(seq):
     ----------
     seq : VariantSequence
     """
-    return -len(seq.sequence)
+    return -len(seq)
 
 def greedy_merge(
         variant_sequences,

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -16,8 +16,6 @@ from __future__ import print_function, division, absolute_import
 
 from collections import defaultdict
 import logging
-# I'd rather just use list.copy but Python 2.7 doesn't support it
-from copy import copy
 
 from .default_parameters import MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE
 
@@ -85,6 +83,26 @@ def greedy_merge(
     for variant_sequence1 in sorted(
             variant_sequences,
             key=sort_by_decreasing_prefix_length):
+        # rather than generating candidate VariantSequence objects for all
+        # pairs of original sequences we check each sequence against the
+        # new sequences generated thus far. If any of them contain the
+        # sequence we're currently considering then just merge it into
+        # those sequences instead.
+        contained_in_existing_supersequence = False
+        for key, candidate_supersequence in list(merged_variant_sequences.items()):
+            if candidate_supersequence.contains(variant_sequence1):
+                contained_in_existing_supersequence = True
+                merged_variant_sequences[key] = candidate_supersequence.combine(variant_sequence1)
+
+        if contained_in_existing_supersequence:
+            continue
+
+        # If this variant sequence wasn't contained in any existing
+        # merged supersequence, try merging it with all the other inputs.
+        # Either we'll find something to merge it with or we'll add the
+        # sequence on its own.
+        found_merge_partner = False
+
         for variant_sequence2 in sorted(
                 variant_sequences,
                 key=sort_by_decreasing_suffix_length):
@@ -92,8 +110,11 @@ def greedy_merge(
                     variant_sequence2,
                     min_overlap_size=min_overlap_size):
                 continue
+            found_merge_partner = True
             combined = variant_sequence1.combine(variant_sequence2)
-            if combined.sequence in merged_variant_sequences:
+            if combined.sequence not in merged_variant_sequences:
+                merged_variant_sequences[combined.sequence] = combined
+            else:
                 # it's possible to get the same merged sequence from distinct
                 # input sequences
                 # For example
@@ -101,15 +122,15 @@ def greedy_merge(
                 #   abcXYZd + bcXYZdddd =  abcXYZdddd
                 # In this case we make a VariantSequence record with the
                 # reads from both original sequences.
-                # TODO: In the future I'd like to track how much of each total
-                # sequence is supported by any one read.
                 existing_record_with_same_sequence = merged_variant_sequences[
                     combined.sequence]
                 combined_with_more_reads = existing_record_with_same_sequence.combine(
                     combined)
                 merged_variant_sequences[combined.sequence] = combined_with_more_reads
-            else:
-                merged_variant_sequences[combined.sequence] = combined
+        if not found_merge_partner:
+            # if we weren't able to merge this sequence with any other
+            # sequences then add it by itself
+            merged_variant_sequences[variant_sequence1.sequence] = variant_sequence1
     return list(merged_variant_sequences.values())
 
 def collapse_substrings(variant_sequences):
@@ -157,35 +178,50 @@ def iterative_overlap_assembly(
         min_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
         n_merge_iters=2):
     """
-    Assembles longer sequences from reads centered on a variant by alternating
+    Assembles longer sequences from reads centered on a variant by
     between merging all pairs of overlapping sequences and collapsing
     shorter sequences onto every longer sequence which contains them.
     """
+    # reduce the number of inputs to the merge algorithm by first collapsing
+    # shorter sequences onto the longer sequences which contain them
+    n_before_collapse = len(variant_sequences)
+
+    variant_sequences = collapse_substrings(variant_sequences)
+    n_after_collapse = len(variant_sequences)
+    logger.info(
+        "Collapsed %d -> %d sequences",
+        n_before_collapse,
+        n_after_collapse)
+
     for i in range(n_merge_iters):
-        previous_sequences = copy(variant_sequences)
-        variant_sequences = greedy_merge(
+        n_before_merge = len(variant_sequences)
+        variant_sequences_after_merge = greedy_merge(
             variant_sequences,
             min_overlap_size=min_overlap_size)
-
+        n_after_merge = len(variant_sequences_after_merge)
         logger.info(
-            "Iteration #%d of assembly: generated %d sequences (from %d)",
+            "Assembly iter %d/%d: merged %d VariantSequences into %d",
             i + 1,
-            len(variant_sequences),
-            len(previous_sequences))
+            n_merge_iters,
+            n_before_merge,
+            n_after_merge)
+        # did the set of variant sequences change? if not, then we're done
+        if set(vs.sequence for vs in variant_sequences) == set(
+                vs.sequence for vs in variant_sequences_after_merge):
+            logger.info("Converged on iter #%d with %d sequences" % (
+                i + 1, n_after_collapse))
+            break
 
-        if len(variant_sequences) == 0:
+        if n_after_merge == 0:
             # if the greedy merge procedure fails for all pairs of candidate
             # sequences then we'll get an empty set of new longer sequences,
             # in which case we should just stop with the results of the last
             # iteration
-            return previous_sequences
-
-        variant_sequences = collapse_substrings(variant_sequences)
-        logger.info(
-            "After collapsing subsequences, %d distinct sequences left",
-            len(variant_sequences))
-        if len(variant_sequences) == 1:
+            return variant_sequences
+        elif n_after_merge == 1:
             # once we have only one sequence then there's no point trying
             # to further combine sequences
-            break
-    return variant_sequences
+            return variant_sequences_after_merge
+        variant_sequences = variant_sequences_after_merge
+    # final cleanup step, merge any VariantSequences which contain each other
+    return collapse_substrings(variant_sequences)

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -19,7 +19,7 @@ import logging
 # I'd rather just use list.copy but Python 2.7 doesn't support it
 from copy import copy
 
-from .default_parameters import MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE
+from .default_parameters import MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def sort_by_decreasing_total_length(seq):
 
 def greedy_merge(
         variant_sequences,
-        min_overlap_size=MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE):
+        min_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE):
     """
     Greedily merge overlapping sequences into longer sequences.
 
@@ -154,7 +154,7 @@ def sort_by_decreasing_read_count_and_sequence_lenth(variant_sequence):
 
 def iterative_overlap_assembly(
         variant_sequences,
-        min_overlap_size=MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
+        min_overlap_size=MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE,
         n_merge_iters=2):
     """
     Assembles longer sequences from reads centered on a variant by alternating

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -41,16 +41,6 @@ def sort_by_decreasing_suffix_length(seq):
     """
     return -len(seq.suffix)
 
-def sort_by_increasing_total_length(seq):
-    """
-    Key function for sorting from shortest to longest total length.
-
-    Parameters
-    ----------
-    seq : VariantSequence
-    """
-    return len(seq.sequence)
-
 def sort_by_decreasing_total_length(seq):
     """
     Key function for sorting from longest to shortest total length.

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -96,7 +96,10 @@ def greedy_merge(
         for variant_sequence2 in sorted(
                 variant_sequences,
                 key=sort_by_decreasing_suffix_length):
-            if not variant_sequence1.left_overlaps(
+            if variant_sequence1 == variant_sequence2:
+                # don't count merging a sequence with itself
+                continue
+            elif not variant_sequence1.left_overlaps(
                     variant_sequence2,
                     min_overlap_size=min_overlap_size):
                 continue
@@ -196,8 +199,8 @@ def iterative_overlap_assembly(
             n_before_merge,
             n_after_merge)
         # did the set of variant sequences change? if not, then we're done
-        if set(vs.sequence for vs in variant_sequences) == set(
-                vs.sequence for vs in variant_sequences_after_merge):
+        if {vs.sequence for vs in variant_sequences} == {
+                vs.sequence for vs in variant_sequences_after_merge}:
             logger.info("Converged on iter #%d with %d sequences" % (
                 i + 1, n_after_collapse))
             break
@@ -214,4 +217,8 @@ def iterative_overlap_assembly(
             return variant_sequences_after_merge
         variant_sequences = variant_sequences_after_merge
     # final cleanup step, merge any VariantSequences which contain each other
+    #
+    # TODO: this used to be necessary in the old greedy_merge implementation
+    # but now might be redundnat with the contains-collapse logic in the
+    # new implementation of greedy_merge.
     return collapse_substrings(variant_sequences)

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -169,7 +169,7 @@ def sort_by_decreasing_read_count_and_sequence_lenth(variant_sequence):
     Sort variant sequences by number of supporting reads and length of
     assembled sequence.
     """
-    return -len(variant_sequence.reads), -len(variant_sequence.sequence)
+    return -len(variant_sequence.reads), -len(variant_sequence)
 
 def iterative_overlap_assembly(
         variant_sequences,

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -236,4 +236,6 @@ def iterative_overlap_assembly(
     # TODO: this used to be necessary in the old greedy_merge implementation
     # but now might be redundnat with the contains-collapse logic in the
     # new implementation of greedy_merge.
-    return collapse_substrings(variant_sequences)
+    return list(sorted(
+        collapse_substrings(variant_sequences),
+        key=sort_by_decreasing_read_count_and_sequence_lenth))

--- a/isovar/cli/protein_sequences.py
+++ b/isovar/cli/protein_sequences.py
@@ -66,7 +66,7 @@ def protein_sequences_generator_from_args(args):
         min_transcript_prefix_length=args.min_transcript_prefix_length,
         max_transcript_mismatches=args.max_reference_transcript_mismatches,
         max_protein_sequences_per_variant=args.max_protein_sequences_per_variant,
-        variant_sequence_assembly=not args.disable_variant_sequence_assembly)
+        variant_sequence_assembly=args.variant_sequence_assembly)
 
 def protein_sequences_dataframe_from_args(args):
     protein_sequences_generator = protein_sequences_generator_from_args(args)

--- a/isovar/cli/protein_sequences.py
+++ b/isovar/cli/protein_sequences.py
@@ -61,10 +61,12 @@ def protein_sequences_generator_from_args(args):
     return reads_generator_to_protein_sequences_generator(
         allele_reads_generator,
         protein_sequence_length=args.protein_sequence_length,
-        min_reads_supporting_cdna_sequence=args.min_reads_supporting_variant_sequence,
+        min_alt_rna_reads=args.min_alt_rna_reads,
+        min_variant_sequence_coverage=args.min_variant_sequence_coverage,
         min_transcript_prefix_length=args.min_transcript_prefix_length,
         max_transcript_mismatches=args.max_reference_transcript_mismatches,
-        max_protein_sequences_per_variant=args.max_protein_sequences_per_variant)
+        max_protein_sequences_per_variant=args.max_protein_sequences_per_variant,
+        variant_sequence_assembly=not args.disable_variant_sequence_assembly)
 
 def protein_sequences_dataframe_from_args(args):
     protein_sequences_generator = protein_sequences_generator_from_args(args)

--- a/isovar/cli/translation.py
+++ b/isovar/cli/translation.py
@@ -80,7 +80,7 @@ def translations_generator_from_args(args):
         protein_sequence_length=args.protein_sequence_length,
         min_alt_rna_reads=args.min_alt_rna_reads,
         min_variant_sequence_coverage=args.min_variant_sequence_coverage,
-        variant_sequence_assembly=not args.disable_variant_sequence_assembly,
+        variant_sequence_assembly=args.variant_sequence_assembly,
         min_transcript_prefix_length=args.min_transcript_prefix_length,
         max_transcript_mismatches=args.max_reference_transcript_mismatches)
 

--- a/isovar/cli/translation.py
+++ b/isovar/cli/translation.py
@@ -78,7 +78,9 @@ def translations_generator_from_args(args):
     return translate_variants(
         variant_reads_generator,
         protein_sequence_length=args.protein_sequence_length,
-        min_reads_supporting_cdna_sequence=args.min_reads_supporting_variant_sequence,
+        min_alt_rna_reads=args.min_alt_rna_reads,
+        min_variant_sequence_coverage=args.min_variant_sequence_coverage,
+        variant_sequence_assembly=not args.disable_variant_sequence_assembly,
         min_transcript_prefix_length=args.min_transcript_prefix_length,
         max_transcript_mismatches=args.max_reference_transcript_mismatches)
 

--- a/isovar/cli/variant_sequences.py
+++ b/isovar/cli/variant_sequences.py
@@ -36,6 +36,7 @@ def add_variant_sequence_args(
 
     rna_sequence_group.add_argument(
         "--min-alt-rna-reads",
+        type=int,
         default=MIN_ALT_RNA_READS,
         help="Minimum number of reads supporting variant allele (default %(default)s)")
 

--- a/isovar/cli/variant_sequences.py
+++ b/isovar/cli/variant_sequences.py
@@ -16,8 +16,9 @@
 from __future__ import print_function, division, absolute_import
 
 from ..default_parameters import (
-    MIN_READS_SUPPORTING_VARIANT_CDNA_SEQUENCE,
-    VARIANT_CDNA_SEQUENCE_LENGTH,
+    MIN_ALT_RNA_READS,
+    MIN_VARIANT_SEQUENCE_COVERAGE,
+    VARIANT_SEQUENCE_LENGTH,
 )
 from ..variant_sequences import (
     reads_generator_to_sequences_generator,
@@ -31,24 +32,31 @@ from .rna_reads import (
 def add_variant_sequence_args(
         parser,
         add_sequence_length_arg=False):
-    rna_sequence_group = parser.add_argument_group("Consensus cDNA sequence")
+    rna_sequence_group = parser.add_argument_group(
+        "Determine coding sequence from RNA")
+
     rna_sequence_group.add_argument(
-        "--min-reads-supporting-variant-sequence",
+        "--min-alt-rna-reads",
+        default=MIN_ALT_RNA_READS,
+        help="Minimum number of reads supporting variant allele (default %(default)s)")
+
+    rna_sequence_group.add_argument(
+        "--min-variant-sequence-coverage",
         type=int,
-        default=MIN_READS_SUPPORTING_VARIANT_CDNA_SEQUENCE,
+        default=MIN_VARIANT_SEQUENCE_COVERAGE,
         help="Minimum number of reads supporting a variant sequence (default %(default)s)")
 
     rna_sequence_group.add_argument(
-        "--variant-sequence-assembly",
-        default=False,
-        action="store_true")
+        "--disable-variant-sequence-assembly",
+        default=True,
+        action="store_false")
 
     # when cDNA sequence length can be inferred from a protein length then
     # we may want to omit this arg
     if add_sequence_length_arg:
         rna_sequence_group.add_argument(
-            "--cdna-sequence-length",
-            default=VARIANT_CDNA_SEQUENCE_LENGTH,
+            "--variant-sequence-length",
+            default=VARIANT_SEQUENCE_LENGTH,
             type=int)
     return parser
 
@@ -80,9 +88,10 @@ def variant_sequences_generator_from_args(args):
     allele_reads_generator = allele_reads_generator_from_args(args)
     return reads_generator_to_sequences_generator(
         allele_reads_generator,
-        min_reads_supporting_cdna_sequence=args.min_reads_supporting_variant_sequence,
+        min_alt_rna_reads=args.min_alt_rna_reads,
+        min_variant_sequence_coverage=args.min_variant_sequence_coverage,
         preferred_sequence_length=args.cdna_sequence_length,
-        variant_cdna_sequence_assembly=args.variant_sequence_assembly)
+        variant_cdna_sequence_assembly=not args.disable_variant_sequence_assembly)
 
 def variant_sequences_dataframe_from_args(args):
     variant_sequences_generator = variant_sequences_generator_from_args(args)

--- a/isovar/cli/variant_sequences.py
+++ b/isovar/cli/variant_sequences.py
@@ -46,7 +46,7 @@ def add_variant_sequence_args(
         help="Minimum number of reads supporting a variant sequence (default %(default)s)")
 
     rna_sequence_group.add_argument(
-        "--no-variant-sequence-assembly",
+        "--disable-variant-sequence-assembly",
         dest="variant_sequence_assembly",
         default=True,
         action="store_false",

--- a/isovar/cli/variant_sequences.py
+++ b/isovar/cli/variant_sequences.py
@@ -91,7 +91,7 @@ def variant_sequences_generator_from_args(args):
         min_alt_rna_reads=args.min_alt_rna_reads,
         min_variant_sequence_coverage=args.min_variant_sequence_coverage,
         preferred_sequence_length=args.cdna_sequence_length,
-        variant_cdna_sequence_assembly=not args.disable_variant_sequence_assembly)
+        variant_sequence_assembly=not args.disable_variant_sequence_assembly)
 
 def variant_sequences_dataframe_from_args(args):
     variant_sequences_generator = variant_sequences_generator_from_args(args)

--- a/isovar/cli/variant_sequences.py
+++ b/isovar/cli/variant_sequences.py
@@ -28,7 +28,6 @@ from .rna_reads import (
     allele_reads_generator_from_args,
     make_rna_reads_arg_parser
 )
-
 def add_variant_sequence_args(
         parser,
         add_sequence_length_arg=False):
@@ -47,10 +46,11 @@ def add_variant_sequence_args(
         help="Minimum number of reads supporting a variant sequence (default %(default)s)")
 
     rna_sequence_group.add_argument(
-        "--disable-variant-sequence-assembly",
+        "--no-variant-sequence-assembly",
+        dest="variant_sequence_assembly",
         default=True,
-        action="store_false")
-
+        action="store_false",
+        help="Disable assemble variant cDNA sequence from overlapping reads")
     # when cDNA sequence length can be inferred from a protein length then
     # we may want to omit this arg
     if add_sequence_length_arg:
@@ -91,7 +91,7 @@ def variant_sequences_generator_from_args(args):
         min_alt_rna_reads=args.min_alt_rna_reads,
         min_variant_sequence_coverage=args.min_variant_sequence_coverage,
         preferred_sequence_length=args.cdna_sequence_length,
-        variant_sequence_assembly=not args.disable_variant_sequence_assembly)
+        variant_sequence_assembly=args.variant_sequence_assembly)
 
 def variant_sequences_dataframe_from_args(args):
     variant_sequences_generator = variant_sequences_generator_from_args(args)

--- a/isovar/common.py
+++ b/isovar/common.py
@@ -16,25 +16,6 @@ from __future__ import print_function, division, absolute_import
 
 from collections import defaultdict
 
-dna_complement_dictionary = {
-    "A": "T",
-    "T": "A",
-    "C": "G",
-    "G": "C",
-}
-
-dna_nucleotides = list(sorted(dna_complement_dictionary.keys()))
-
-dna_nucleotide_to_index = {c: i for (i, c) in enumerate(dna_nucleotides)}
-
-index_to_dna_nucleotide = {i: c for (i, c) in enumerate(dna_nucleotides)}
-
-def complement_dna(seq):
-    return "".join(dna_complement_dictionary[nt] for nt in seq)
-
-def reverse_complement_dna(seq):
-    return complement_dna(seq)[::-1]
-
 def list_to_string(list_of_anything, sep=";"):
     """
     Helper function used for building the fields of a printable dataframe

--- a/isovar/default_parameters.py
+++ b/isovar/default_parameters.py
@@ -49,15 +49,19 @@ USE_DUPLICATE_READS = False
 USE_SECONDARY_ALIGNMENTS = True
 
 # number of nucleotides to extract from RNAseq reads around each variant
-VARIANT_CDNA_SEQUENCE_LENGTH = 90
+VARIANT_SEQUENCE_LENGTH = 90
 
 # number of nucleotides to the left and right of a variant to extract,
 # usually gets adjusted for variant length but some functions take this
 # parameter directly
-CDNA_CONTEXT_SIZE = VARIANT_CDNA_SEQUENCE_LENGTH // 2
+CDNA_CONTEXT_SIZE = VARIANT_SEQUENCE_LENGTH // 2
 
-# only consider variant cDNA sequences with at least this many reads
-MIN_READS_SUPPORTING_VARIANT_CDNA_SEQUENCE = 2
+# minimum number of total RNA reads supporting a variant allele
+MIN_ALT_RNA_READS = 2
+
+# minimum number of reads supporting each nucleotide of a
+# variant coding sequence
+MIN_VARIANT_SEQUENCE_COVERAGE = 2
 
 # number of nucleotides shared between reference and variant sequence
 # before variant for reference contexts used to establish ORF
@@ -76,10 +80,10 @@ MAX_PROTEIN_SEQUENCES_PER_VARIANT = 1
 # run overlap assembly algorithm to construct variant
 # sequences from multiple reads which only partially
 # overlap (rather than fully spanning a coding sequence)
-VARIANT_CDNA_SEQUENCE_ASSEMBLY = False
+VARIANT_SEQUENCE_ASSEMBLY = False
 
 # Only merge variant cDNA sequences which at least share
 # this number of nucleotides. Should be sufficiently high
 # to minimize false assembly of isoforms which don't
 # actually exist.
-MIN_VARIANT_CDNA_SEQUENCE_ASSEMBLY_OVERLAP_SIZE = 30
+MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE = 30

--- a/isovar/locus_reads.py
+++ b/isovar/locus_reads.py
@@ -131,7 +131,6 @@ class LocusRead(namedtuple("LocusRead", [
             logger.warn("Read '%s' missing base qualities", name)
             return None
 
-        #
         # Documentation for pysam.AlignedSegment.get_reference_positions:
         # ------------------------------------------------------------------
         # By default, this method only returns positions in the reference
@@ -248,7 +247,6 @@ def locus_read_generator(
 
     Yields ReadAtLocus objects
     """
-
     logger.debug(
         "Gathering reads at locus %s: %d-%d",
         chromosome,

--- a/isovar/locus_reads.py
+++ b/isovar/locus_reads.py
@@ -107,6 +107,7 @@ class LocusRead(namedtuple("LocusRead", [
         mapping_quality = read.mapping_quality
 
         missing_mapping_quality = mapping_quality is None
+
         if min_mapping_quality > 0 and missing_mapping_quality:
             logger.debug("Skipping read '%s' due to missing MAPQ", name)
             return None

--- a/isovar/nucleotide_counts.py
+++ b/isovar/nucleotide_counts.py
@@ -16,7 +16,7 @@ from __future__ import print_function, division, absolute_import
 
 import numpy as np
 
-from .common import (
+from .dna import (
     dna_nucleotide_to_index,
     index_to_dna_nucleotide,
 )

--- a/isovar/protein_sequences.py
+++ b/isovar/protein_sequences.py
@@ -29,8 +29,9 @@ from .default_parameters import (
     MAX_REFERENCE_TRANSCRIPT_MISMATCHES,
     PROTEIN_SEQUENCE_LENGTH,
     MAX_PROTEIN_SEQUENCES_PER_VARIANT,
-    MIN_READS_SUPPORTING_VARIANT_CDNA_SEQUENCE,
-    VARIANT_CDNA_SEQUENCE_ASSEMBLY
+    MIN_ALT_RNA_READS,
+    MIN_VARIANT_SEQUENCE_COVERAGE,
+    VARIANT_SEQUENCE_ASSEMBLY
 )
 from .dataframe_builder import dataframe_from_generator
 from .translation import translate_variant_reads, Translation, TranslationKey
@@ -144,11 +145,12 @@ def reads_generator_to_protein_sequences_generator(
         variant_and_overlapping_reads_generator,
         transcript_id_whitelist=None,
         protein_sequence_length=PROTEIN_SEQUENCE_LENGTH,
-        min_reads_supporting_cdna_sequence=MIN_READS_SUPPORTING_VARIANT_CDNA_SEQUENCE,
+        min_alt_rna_reads=MIN_ALT_RNA_READS,
+        min_variant_sequence_coverage=MIN_VARIANT_SEQUENCE_COVERAGE,
         min_transcript_prefix_length=MIN_TRANSCRIPT_PREFIX_LENGTH,
         max_transcript_mismatches=MAX_REFERENCE_TRANSCRIPT_MISMATCHES,
         max_protein_sequences_per_variant=MAX_PROTEIN_SEQUENCES_PER_VARIANT,
-        variant_cdna_sequence_assembly=VARIANT_CDNA_SEQUENCE_ASSEMBLY):
+        variant_sequence_assembly=VARIANT_SEQUENCE_ASSEMBLY):
     """"
     Translates each coding variant in a collection to one or more
     Translation objects, which are then aggregated into equivalent
@@ -156,6 +158,10 @@ def reads_generator_to_protein_sequences_generator(
 
     Parameters
     ----------
+    variant_and_overlapping_reads_generator : generator
+        Yields sequence of varcode.Variant objects paired with sequences
+        of AlleleRead objects that support that variant.
+
     transcript_id_whitelist : set, optional
         If given, expected to be a set of transcript IDs which we should use
         for determining the reading frame around a variant. If omitted, then
@@ -166,8 +172,13 @@ def reads_generator_to_protein_sequences_generator(
         we'll have to return something shorter (depending on the RNAseq data,
         and presence of stop codons).
 
-    min_reads_supporting_cdna_sequence : int
-        Drop variant sequences supported by fewer than this number of reads.
+    min_alt_rna_reads : int
+        Drop variant sequences at loci with fewer than this number of reads
+        supporting the alt allele.
+
+    min_variant_sequence_coverage : int
+        Trim variant sequences to positions supported by at least this number
+        of RNA reads.
 
     min_transcript_prefix_length : int
         Minimum number of bases we need to try matching between the reference
@@ -206,10 +217,11 @@ def reads_generator_to_protein_sequences_generator(
             variant_reads=alt_reads,
             transcript_id_whitelist=transcript_id_whitelist,
             protein_sequence_length=protein_sequence_length,
-            min_reads_supporting_cdna_sequence=min_reads_supporting_cdna_sequence,
+            min_alt_rna_reads=min_alt_rna_reads,
+            min_variant_sequence_coverage=min_variant_sequence_coverage,
             min_transcript_prefix_length=min_transcript_prefix_length,
             max_transcript_mismatches=max_transcript_mismatches,
-            variant_cdna_sequence_assembly=variant_cdna_sequence_assembly)
+            variant_sequence_assembly=variant_sequence_assembly)
 
         protein_sequences = []
         for (key, equivalent_translations) in groupby(

--- a/isovar/read_helpers.py
+++ b/isovar/read_helpers.py
@@ -19,6 +19,8 @@ Helper functions for working with RNA reads
 from __future__ import print_function, division, absolute_import
 from collections import defaultdict
 
+from .common import groupby
+
 def get_single_allele_from_reads(allele_reads):
     """
     Given a sequence of AlleleRead objects, which are expected to all have
@@ -84,7 +86,4 @@ def group_reads_by_allele(allele_reads):
     Returns dictionary mapping each allele's nucleotide sequence to a list of
     supporting AlleleRead objects.
     """
-    allele_to_reads_dict = defaultdict(list)
-    for allele_read in allele_reads:
-        allele_to_reads_dict[allele_read.allele].append(allele_read)
-    return allele_to_reads_dict
+    return groupby(allele_reads, lambda read: read.allele)

--- a/isovar/translation.py
+++ b/isovar/translation.py
@@ -406,7 +406,7 @@ def translate_variant_reads(
         Drop variant sequences from loci with fewer than this number of
         RNA reads supporting the alt allele.
 
-    min_reads_supporting_cdna_sequence : int
+    min_variant_sequence_coverage : int
         Trim variant sequences to nucleotides covered by at least this many
         reads.
 
@@ -496,7 +496,7 @@ def translate_variants(
         Drop variant sequences from loci with fewer than this number of
         RNA reads supporting the alt allele.
 
-    min_reads_supporting_cdna_sequence : int
+    min_variant_sequence_coverage : int
         Trim variant sequences to nucleotides covered by at least this many
         reads.
 

--- a/isovar/variant_sequences.py
+++ b/isovar/variant_sequences.py
@@ -256,12 +256,12 @@ def initial_variant_sequences_from_reads(
 
 def filter_variant_sequences_by_read_support(
         variant_sequences,
-        min_reads_supporting_cdna_sequence):
+        min_variant_sequence_coverage):
     n_total = len(variant_sequences)
     variant_sequences = [
         s
         for s in variant_sequences
-        if s.min_coverage() >= min_reads_supporting_cdna_sequence
+        if s.min_coverage() >= min_variant_sequence_coverage
     ]
     n_dropped = n_total - len(variant_sequences)
     if n_dropped > 0:
@@ -269,7 +269,7 @@ def filter_variant_sequences_by_read_support(
             "Dropped %d/%d variant sequences less than %d supporting reads",
             n_dropped,
             n_total,
-            min_reads_supporting_cdna_sequence)
+            min_variant_sequence_coverage)
     return variant_sequences
 
 def filter_variant_sequences_by_length(

--- a/isovar/variant_sequences.py
+++ b/isovar/variant_sequences.py
@@ -135,7 +135,10 @@ class VariantSequence(VariantSequenceBase):
     def combine(self, other_sequence):
         """
         If this sequence is the prefix of another sequence, combine
-        them into a single VariantSequence object.
+        them into a single VariantSequence object. If the other sequence
+        is contained in this one, then add its reads to this VariantSequence.
+        Also tries to flip the order (e.g. this sequence is a suffix or
+        this sequence is a subsequence).
         """
         if other_sequence.alt != self.alt:
             raise ValueError(
@@ -232,9 +235,6 @@ class VariantSequence(VariantSequenceBase):
             alt=self.alt,
             suffix=self.suffix[:last_covered_index - variant_end_index + 1],
             reads=self.reads)
-
-    def sort_key_decreasing_read_count(self):
-        return -len(self.reads)
 
 def initial_variant_sequences_from_reads(
         variant_reads,
@@ -456,7 +456,7 @@ def reads_to_variant_sequences(
 
     # sort VariantSequence objects by decreasing order of supporting read
     # counts
-    variant_sequences.sort(key=VariantSequence.sort_key_decreasing_read_count)
+    variant_sequences.sort(key=lambda vs: -len(vs.reads))
     return variant_sequences
 
 def reads_generator_to_sequences_generator(

--- a/test/test_assembly.py
+++ b/test/test_assembly.py
@@ -202,3 +202,41 @@ def test_assembly_time():
     assert t_elapsed < 0.1, \
         "Expected assembly of 400 sequences to take less than 100ms: %0.4fms" % (
             t_elapsed * 1000,)
+
+def test_assembly_unrelated_sequences():
+    # 2 overlapping sequences, 1 with a different suffix,
+    # and 2 totally unrelated sequences
+    variant_sequences = [
+        VariantSequence(
+            prefix="CCC",
+            alt="T",
+            suffix="GGG",
+            reads={"1"}),
+        VariantSequence(
+            prefix="TCCC",
+            alt="T",
+            suffix="G",
+            reads={"2"}),
+        VariantSequence(
+            prefix="CCC",
+            alt="T",
+            suffix="AAA",
+            reads={"3"}),
+        VariantSequence(
+            prefix="AGG",
+            alt="T",
+            suffix="CGG",
+            reads={"4"}),
+        VariantSequence(
+            prefix="CAC",
+            alt="T",
+            suffix="TTT",
+            reads={"5"})
+    ]
+    results = iterative_overlap_assembly(
+        variant_sequences, min_overlap_size=1)
+    eq_(len(results), 4)
+    # first two sequences were overlapping
+    eq_(results[0].reads, {"1", "2"})
+    for singleton_result in results[1:]:
+        eq_(len(singleton_result.reads), 1)

--- a/test/test_assembly.py
+++ b/test/test_assembly.py
@@ -160,17 +160,19 @@ def test_assembly_of_many_subsequences():
         suffix=original_suffix,
         reads={"decoy"})
     input_sequences = subsequences + [decoy]
-    for fn in [iterative_overlap_assembly, greedy_merge]:
-        results = fn(input_sequences, min_overlap_size=len(original_allele))
-        eq_(len(results), 2)
-        result = results[0]
-        eq_(result.prefix, original_prefix)
-        eq_(result.alt, original_allele)
-        eq_(result.suffix, original_suffix)
-        eq_(len(result.reads), len(subsequences))
+    results = iterative_overlap_assembly(
+        input_sequences, min_overlap_size=len(original_allele))
 
-        result_decoy = results[1]
-        eq_(result_decoy.sequence, decoy.sequence)
+    eq_(len(results), 2)
+
+    result = results[0]
+    eq_(result.prefix, original_prefix)
+    eq_(result.alt, original_allele)
+    eq_(result.suffix, original_suffix)
+    eq_(len(result.reads), len(subsequences))
+
+    result_decoy = results[1]
+    eq_(result_decoy.sequence, decoy.sequence)
 
 def test_assembly_time():
     original_prefix = "ACTGAACCTTGGAAACCCTTTGGG"
@@ -240,3 +242,14 @@ def test_assembly_unrelated_sequences():
     eq_(results[0].reads, {"1", "2"})
     for singleton_result in results[1:]:
         eq_(len(singleton_result.reads), 1)
+
+def test_assembly_no_sequences():
+    eq_(iterative_overlap_assembly([]), [])
+
+def test_assembly_1_sequence():
+    vs = VariantSequence(
+        prefix="CCC",
+        alt="T",
+        suffix="GGG",
+        reads={"1"})
+    eq_(iterative_overlap_assembly([vs]), [vs])

--- a/test/test_assembly.py
+++ b/test/test_assembly.py
@@ -134,3 +134,29 @@ def test_collapse_substrings():
     vs_combined = vs_longer.add_reads({"2"})
     assert vs_combined in results, "Expeceted %s to be in %s" % (vs_combined, results)
     assert vs_unrelated in results, "Expected %s to be in %s" % (vs_unrelated, results)
+
+
+def test_assembly_of_many_subsequences():
+    original_prefix = "ACTGAACCTTGGAAACCCTTTGGG"
+    original_allele = "CCCTTT"
+    original_suffix = "GGAAGGAAGGAATTTTTTTT"
+
+    # generate 100 subsequences of all combinations of 0-9
+    # characters trimmed from beginning of prefix vs. end of suffix
+    subsequences = [
+        VariantSequence(
+            prefix=original_prefix[i:],
+            alt=original_allele,
+            suffix=original_suffix[:-j] if j > 0 else original_suffix,
+            reads={str(i) + "_" + str(j)})
+        for i in range(10)
+        for j in range(10)
+    ]
+    for fn in [iterative_overlap_assembly, greedy_merge]:
+        results = fn(subsequences, min_overlap_size=len(original_allele))
+        eq_(len(results), 1)
+        result = results[0]
+        eq_(result.prefix, original_prefix)
+        eq_(result.alt, original_allele)
+        eq_(result.suffix, original_suffix)
+        eq_(len(result.reads), len(subsequences))

--- a/test/test_assembly.py
+++ b/test/test_assembly.py
@@ -15,10 +15,13 @@
 from __future__ import print_function, division, absolute_import
 
 from isovar.variant_reads import reads_supporting_variant
-from isovar.variant_sequences import initial_variant_sequences_from_reads
+from isovar.variant_sequences import (
+    initial_variant_sequences_from_reads,
+    VariantSequence
+)
 from isovar.allele_reads import AlleleRead
-from isovar.variant_sequences import VariantSequence
 from isovar.assembly import iterative_overlap_assembly
+
 from pyensembl import ensembl_grch38
 from varcode import Variant
 from nose.tools import eq_
@@ -61,7 +64,6 @@ def test_assemble_transcript_fragments_snv():
                 max_read_length,)
 
 def test_assembly_of_simple_sequence_from_mock_reads():
-    #
     # Read sequences:
     #    AAAAA|CC|TTTTT
     #    AAAAA|CC|TTTTT
@@ -72,7 +74,11 @@ def test_assembly_of_simple_sequence_from_mock_reads():
         AlleleRead(prefix="A" * 5, allele="CC", suffix="T" * 5, name="dup1"),
         AlleleRead(prefix="A" * 5, allele="CC", suffix="T" * 5, name="dup2"),
         # longer sequence GAAAAA|CC|TTTTTG
-        AlleleRead(prefix="G" + "A" * 5, allele="CC", suffix="T" * 5 + "G", name="longer"),
+        AlleleRead(
+            prefix="G" + "A" * 5,
+            allele="CC",
+            suffix="T" * 5 + "G",
+            name="longer"),
         # shorter sequence AAAA|CC|TTTT
         AlleleRead(prefix="A" * 4, allele="CC", suffix="T" * 4, name="shorter"),
     ]

--- a/test/test_assembly.py
+++ b/test/test_assembly.py
@@ -152,11 +152,21 @@ def test_assembly_of_many_subsequences():
         for i in range(10)
         for j in range(10)
     ]
+    # adding one decoy sequence which doesn't match
+    decoy = VariantSequence(
+        prefix="G" + original_prefix[1:],
+        alt=original_allele,
+        suffix=original_suffix,
+        reads={"decoy"})
+    input_sequences = subsequences + [decoy]
     for fn in [iterative_overlap_assembly, greedy_merge]:
-        results = fn(subsequences, min_overlap_size=len(original_allele))
-        eq_(len(results), 1)
+        results = fn(input_sequences, min_overlap_size=len(original_allele))
+        eq_(len(results), 2)
         result = results[0]
         eq_(result.prefix, original_prefix)
         eq_(result.alt, original_allele)
         eq_(result.suffix, original_suffix)
         eq_(len(result.reads), len(subsequences))
+
+        result_decoy = results[1]
+        eq_(result_decoy.sequence, decoy.sequence)

--- a/test/test_assembly.py
+++ b/test/test_assembly.py
@@ -59,9 +59,12 @@ def test_assemble_transcript_fragments_snv():
             len(s.reads),
             len(s.sequence)))
         eq_(s.alt, alt)
-        assert len(s) > max_read_length, \
-            "Expected assembled sequences to be longer than read length (%d)" % (
-                max_read_length,)
+        if len(s.read_names) > 1:
+            # expect sequences supported by more than one read to be greater
+            # than the read length
+            assert len(s) > max_read_length, \
+                "Expected assembled sequences to be longer than read length (%d)" % (
+                    max_read_length,)
 
 def test_assembly_of_simple_sequence_from_mock_reads():
     # Read sequences:

--- a/test/test_assembly.py
+++ b/test/test_assembly.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
+from time import time
 
 from isovar.variant_reads import reads_supporting_variant
 from isovar.variant_sequences import (
@@ -170,3 +171,34 @@ def test_assembly_of_many_subsequences():
 
         result_decoy = results[1]
         eq_(result_decoy.sequence, decoy.sequence)
+
+def test_assembly_time():
+    original_prefix = "ACTGAACCTTGGAAACCCTTTGGG"
+    original_allele = "CCCTTT"
+    original_suffix = "GGAAGGAAGGAATTTTTTTTGGCC"
+
+    # generate 400 subsequences of all combinations of 0-19
+    # characters trimmed from beginning of prefix vs. end of suffix
+    subsequences = [
+        VariantSequence(
+            prefix=original_prefix[i:],
+            alt=original_allele,
+            suffix=original_suffix[:-j] if j > 0 else original_suffix,
+            reads={str(i) + "_" + str(j)})
+        for i in range(20)
+        for j in range(20)
+    ]
+    eq_(len(subsequences), 400)
+    t_start = time()
+    results = iterative_overlap_assembly(
+        subsequences,
+        min_overlap_size=len(original_allele))
+    t_end = time()
+    eq_(len(results), 1)
+    result = results[0]
+    eq_(result.prefix, original_prefix)
+    eq_(result.suffix, original_suffix)
+    t_elapsed = t_end - t_start
+    assert t_elapsed < 0.1, \
+        "Expected assembly of 400 sequences to take less than 100ms: %0.4fms" % (
+            t_elapsed * 1000,)

--- a/test/test_dna_helpers.py
+++ b/test/test_dna_helpers.py
@@ -1,7 +1,9 @@
-from isovar.common import reverse_complement_dna
+from isovar.dna import reverse_complement_dna, complement_dna
 from nose.tools import eq_
 
 def test_reverse_complement_dna():
-    eq_(
-        "ATGCAATTGGCC",
+    eq_("ATGCAATTGGCC",
         reverse_complement_dna("GGCCAATTGCAT"))
+
+def test_complement_dna():
+    eq_("ATGC", complement_dna("TACG"))

--- a/test/test_nucleotide_counts.py
+++ b/test/test_nucleotide_counts.py
@@ -23,7 +23,6 @@ from nose.tools import eq_
 
 from testing_helpers import load_bam
 
-
 def test_most_common_nucleotides_for_chr12_deletion():
     samfile = load_bam("data/cancer-wgs-primary.chr12.bam")
     chromosome = "chr12"
@@ -58,6 +57,3 @@ def test_most_common_nucleotides_for_chr12_deletion():
         number_matching_reads, len(variant_reads), fraction_matching_reads))
     assert fraction_matching_reads > 0.5, \
         "Expected majority of reads to match consensus sequence"
-
-if __name__ == "__main__":
-    test_most_common_nucleotides_for_chr12_deletion()

--- a/test/test_protein_sequences.py
+++ b/test/test_protein_sequences.py
@@ -161,7 +161,7 @@ def variants_to_protein_sequences_dataframe(
         tumor_rna_bam="data/b16.f10/b16.combined.sorted.bam",
         min_mapping_quality=0,
         max_protein_sequences_per_variant=1,
-        variant_cdna_sequence_assembly=False):
+        variant_sequence_assembly=False):
     """
     Helper function to load pair of VCFs and tumor RNA BAM
     and use them to generate a DataFrame of expressed variant protein
@@ -182,13 +182,13 @@ def variants_to_protein_sequences_dataframe(
     protein_sequences_generator = reads_generator_to_protein_sequences_generator(
         allele_reads_generator,
         max_protein_sequences_per_variant=max_protein_sequences_per_variant,
-        variant_cdna_sequence_assembly=variant_cdna_sequence_assembly)
+        variant_sequence_assembly=variant_sequence_assembly)
     df = protein_sequences_generator_to_dataframe(protein_sequences_generator)
     return df, expressed_variants, combined_variants
 
 def test_variants_to_protein_sequences_dataframe_one_sequence_per_variant_with_assembly():
     df, expressed_variants, combined_variants = \
-        variants_to_protein_sequences_dataframe(variant_cdna_sequence_assembly=True)
+        variants_to_protein_sequences_dataframe(variant_sequence_assembly=True)
     print(df)
     eq_(len(df),
         len(expressed_variants),
@@ -199,7 +199,7 @@ def test_variants_to_protein_sequences_dataframe_one_sequence_per_variant_with_a
 
 def test_variants_to_protein_sequences_dataframe_one_sequence_per_variant_without_assembly():
     df, expressed_variants, combined_variants = \
-        variants_to_protein_sequences_dataframe(variant_cdna_sequence_assembly=False)
+        variants_to_protein_sequences_dataframe(variant_sequence_assembly=False)
     print(df)
     eq_(len(df),
         len(expressed_variants),
@@ -251,10 +251,3 @@ def test_variants_to_protein_sequences_dataframe_protein_sequence_length():
         protien_sequence_lengths = protein_sequences.str.len()
         assert (protien_sequence_lengths == desired_length).all(), (
             protien_sequence_lengths,)
-
-if __name__ == "__main__":
-    test_sort_protein_sequences()
-    test_variants_to_protein_sequences_dataframe_one_sequence_per_variant_with_assembly()
-    test_variants_to_protein_sequences_dataframe_one_sequence_per_variant_without_assembly()
-    test_variants_to_protein_sequences_dataframe_filtered_all_reads_by_mapping_quality()
-    test_variants_to_protein_sequences_dataframe_protein_sequence_length()

--- a/test/test_protein_sequences.py
+++ b/test/test_protein_sequences.py
@@ -225,7 +225,7 @@ def test_variants_to_protein_sequences_dataframe_filtered_all_reads_by_mapping_q
     eq_(
         len(df),
         0,
-        "Expected 0 entries, got %d" % (len(df),))
+        "Expected 0 entries, got %d: %s" % (len(df), df))
 
 def test_variants_to_protein_sequences_dataframe_protein_sequence_length():
     expressed_variants = load_vcf("data/b16.f10/b16.expressed.vcf")
@@ -242,10 +242,11 @@ def test_variants_to_protein_sequences_dataframe_protein_sequence_length():
         eq_(
             len(df),
             len(expressed_variants),
-            "Expected %d entries for protein_sequnece_length=%d, got %d results" % (
+            "Expected %d entries for protein_sequnece_length=%d, got %d results: %s" % (
                 len(expressed_variants),
                 desired_length,
-                len(df)))
+                len(df),
+                df))
         protein_sequences = df["amino_acids"]
         print(protein_sequences)
         protien_sequence_lengths = protein_sequences.str.len()

--- a/test/test_variant_sequences.py
+++ b/test/test_variant_sequences.py
@@ -16,8 +16,12 @@ from __future__ import print_function, division, absolute_import
 
 from nose.tools import eq_
 from varcode import Variant
-from isovar.variant_sequences import reads_to_variant_sequences
+from isovar.variant_sequences import (
+    reads_to_variant_sequences,
+    VariantSequence
+)
 from isovar.variant_reads import reads_supporting_variant
+from isovar.allele_reads import AlleleRead
 
 from testing_helpers import load_bam
 
@@ -48,5 +52,246 @@ def test_sequence_counts_snv():
             variant_sequence.prefix + variant_sequence.alt + variant_sequence.suffix,
             variant_sequence.sequence)
 
-if __name__ == "__main__":
-    test_sequence_counts_snv()
+
+def test_variant_sequence_read_names():
+    vs = VariantSequence(
+        prefix="A",
+        alt="C",
+        suffix="T",
+        reads=[
+            AlleleRead(prefix="A", allele="C", suffix="T", name="1"),
+            AlleleRead(prefix="A", allele="C", suffix="T", name="2")])
+    eq_(vs.read_names, {"1", "2"})
+
+def test_variant_sequence_contains():
+    # AA|C|T
+    vs_longer_prefix = VariantSequence(
+        prefix="AA",
+        alt="C",
+        suffix="T",
+        reads=[
+            AlleleRead(
+                prefix="AA", allele="C", suffix="T", name="longer_prefix")])
+    # A|C|TT
+    vs_longer_suffix = VariantSequence(
+        prefix="A",
+        alt="C",
+        suffix="TT",
+        reads=[
+            AlleleRead(
+                prefix="A", allele="C", suffix="TT", name="longer_suffix")])
+    # A|C|T
+    vs_short = VariantSequence(
+        prefix="A",
+        alt="C",
+        suffix="T",
+        reads=[
+            AlleleRead(
+                prefix="A", allele="C", suffix="T", name="short")])
+
+    # two longer sequences contain the shorter subsequence
+    assert vs_longer_prefix.contains(vs_short), \
+        "Expected %s to contain %s" % (vs_longer_prefix, vs_short)
+    assert vs_longer_suffix.contains(vs_short), \
+        "Expected %s to contain %s" % (vs_longer_suffix, vs_short)
+    # other pairs do not contain each other
+    assert not vs_longer_prefix.contains(vs_longer_suffix), \
+        "Expected %s to not contain %s" % (vs_longer_prefix, vs_longer_suffix)
+    assert not vs_longer_suffix.contains(vs_longer_prefix), \
+        "Expected %s to not contain %s" % (vs_longer_suffix, vs_longer_prefix)
+    assert not vs_short.contains(vs_longer_prefix), \
+        "Expected %s to not contain %s" % (vs_short, vs_longer_prefix)
+    assert not vs_short.contains(vs_longer_suffix), \
+        "Expected %s to not contain %s" % (vs_short, vs_longer_suffix)
+
+    # Sequences above has 'C' allele whereas this one has 'G'
+    # A|G|T
+    vs_different_allele = VariantSequence(
+        prefix="A",
+        alt="G",
+        suffix="T",
+        reads=[
+            AlleleRead(
+                prefix="A", allele="G", suffix="T", name="short")])
+
+    for vs in [vs_longer_suffix, vs_longer_prefix, vs_short]:
+        assert not vs.contains(vs_different_allele), \
+            "Expected %s to not contain %s" % (vs, vs_different_allele)
+        assert not vs_different_allele.contains(vs), \
+            "Expected %s to not contain %s" % (vs_different_allele, vs)
+
+def test_variant_sequence_overlaps():
+    # AAA|GG|TT
+    vs_3A = VariantSequence(
+        prefix="AAA",
+        alt="GG",
+        suffix="TT",
+        reads=[
+            AlleleRead(
+                prefix="AAA", allele="GG", suffix="TT", name="1")])
+    vs_2A = VariantSequence(
+        prefix="AA",
+        alt="GG",
+        suffix="TT",
+        reads=[
+            AlleleRead(
+                prefix="AA", allele="GG", suffix="TT", name="1")])
+    for min_overlap_size in [1, 2, 3, 4, 5, 6]:
+        assert vs_3A.left_overlaps(vs_2A, min_overlap_size=min_overlap_size), \
+            "Expected %s to overlap %s from left (min overlap size=%d)" % (
+                vs_3A, vs_2A, min_overlap_size)
+
+        assert not vs_2A.left_overlaps(vs_3A, min_overlap_size=min_overlap_size), \
+            "Expected %s to not overlap %s from left (min overlap size=%d)" % (
+                vs_2A, vs_3A, min_overlap_size)
+
+
+"""
+class VariantSequence(VariantSequenceBase):
+    def __new__(cls, prefix, alt, suffix, reads):
+        # construct sequence from prefix + alt + suffix
+        return VariantSequenceBase.__new__(
+            cls,
+            prefix=prefix,
+            alt=alt,
+            suffix=suffix,
+            sequence=prefix + alt + suffix,
+            reads=frozenset(reads))
+
+    def __len__(self):
+        return len(self.sequence)
+
+    @property
+    def read_names(self):
+        return {r.name for r in self.reads}
+
+    def contains(self, other):
+        return (self.alt == other.alt and
+                self.prefix.endswith(other.prefix) and
+                self.suffix.startswith(other.suffix))
+
+    def left_overlaps(self, other, min_overlap_size=1):
+        if self.alt != other.alt:
+            # allele must match!
+            return False
+
+        if len(other.prefix) > len(self.prefix):
+            # only consider strings that overlap like:
+            #   variant_sequence1: ppppAssss
+            #   variant_sequence2:   ppAsssssss
+            # which excludes cases where variant_sequence2 has a longer
+            # prefix
+            return False
+        elif len(other.suffix) < len(self.suffix):
+            # similarly, we throw cases where variant_sequence2 is shorter
+            # after the alt nucleotides than variant_sequence1
+            return False
+
+        # is the candidate sequence is a prefix of the accepted?
+        # Example:
+        # p1 a1 s1 = XXXXXXXX Y ZZZZZZ
+        # p2 a2 s2 =       XX Y ZZZZZZZZZ
+        # ...
+        # then we can combine them into a longer sequence
+        sequence_overlaps = (
+            self.prefix.endswith(other.prefix) and
+            other.suffix.startswith(self.suffix)
+        )
+        prefix_overlap_size = len(self.prefix) - len(other.prefix)
+        suffix_overlap_size = len(other.suffix) - len(self.suffix)
+        overlap_size = prefix_overlap_size + suffix_overlap_size + len(self.alt)
+        return sequence_overlaps and overlap_size >= min_overlap_size
+
+    def add_reads(self, reads):
+        return VariantSequence(
+            prefix=self.prefix,
+            alt=self.alt,
+            suffix=self.suffix,
+            reads=self.reads.union(reads))
+
+    def combine(self, other_sequence):
+        if other_sequence.alt != self.alt:
+            raise ValueError(
+                "Cannot combine %s and %s with mismatching alt sequences" % (
+                    self,
+                    other_sequence))
+        elif self.left_overlaps(other_sequence):
+            # If sequences are like AABC and ABCC
+            return VariantSequence(
+                prefix=self.prefix,
+                alt=self.alt,
+                suffix=other_sequence.suffix,
+                reads=self.reads.union(other_sequence.reads))
+        elif other_sequence.left_overlaps(self):
+            return other_sequence.combine(self)
+        elif self.contains(other_sequence):
+            return self.add_reads(other_sequence.reads)
+        elif other_sequence.contains(self):
+            return other_sequence.add_reads(self.reads)
+        else:
+            raise ValueError("%s does not overlap with %s" % (self, other_sequence))
+
+    def variant_indices(self):
+        variant_start_index = len(self.prefix)
+        variant_len = len(self.alt)
+        variant_end_index = variant_start_index + variant_len
+        return variant_start_index, variant_end_index
+
+    def coverage(self):
+        variant_start_index, variant_end_index = self.variant_indices()
+        n_nucleotides = len(self)
+        coverage_array = np.zeros(n_nucleotides, dtype="int32")
+        for read in self.reads:
+            coverage_array[
+                max(0, variant_start_index - len(read.prefix)):
+                min(n_nucleotides, variant_end_index + len(read.suffix))] += 1
+        return coverage_array
+
+    def min_coverage(self):
+        return np.min(self.coverage())
+
+    def mean_coverage(self):
+        return np.mean(self.coverage())
+
+    def trim_by_coverage(self, min_reads):
+        read_count_array = self.coverage()
+        logger.info("Coverage: %s (len=%d)" % (
+            read_count_array, len(read_count_array)))
+        sufficient_coverage_mask = read_count_array >= min_reads
+        sufficient_coverage_indices = np.argwhere(sufficient_coverage_mask)
+        if len(sufficient_coverage_indices) == 0:
+            logger.debug("No bases in %s have coverage >= %d" % (self, min_reads))
+            return VariantSequence(prefix="", alt="", suffix="", reads=self.reads)
+        variant_start_index, variant_end_index = self.variant_indices()
+        # assuming that coverage drops off monotonically away from
+        # variant nucleotides
+        first_covered_index = sufficient_coverage_indices.min()
+        last_covered_index = sufficient_coverage_indices.max()
+        # adding 1 to last_covered_index since it's an inclusive index
+        # whereas variant_end_index is the end of a half-open interval
+        if (first_covered_index > variant_start_index or
+                last_covered_index + 1 < variant_end_index):
+            # Example:
+            #   Nucleotide sequence:
+            #       ACCCTTTT|AA|GGCGCGCC
+            #   Coverage:
+            #       12222333|44|33333211
+            # Then the mask for bases covered >= 4x would be:
+            #       ________|**|________
+            # with indices:
+            #       first_covered_index = 9
+            #       last_covered_index = 10
+            #       variant_start_index = 9
+            #       variant_end_index = 11
+            logger.debug("Some variant bases in %s don't have coverage >= %d" % (
+                self, min_reads))
+            return VariantSequence(prefix="", alt="", suffix="", reads=self.reads)
+        return VariantSequence(
+            prefix=self.prefix[first_covered_index:],
+            alt=self.alt,
+            suffix=self.suffix[:last_covered_index - variant_end_index + 1],
+            reads=self.reads)
+
+    def sort_key_decreasing_read_count(self):
+        return -len(self.reads)
+"""


### PR DESCRIPTION
CLI args:

`--min-alt-rna-reads`: If a variant has fewer than this number of RNA reads supporting it then skip it before even trying to construct variant cDNA sequences.

`--min-variant-sequence-coverage`: Trim VariantSequence objects to only positions which are spanned by at least this number of variant-supporting reads (and drop the VariantSequence if not bases are sufficiently covered). 

Also, for consistency, I renamed the other function arguments from e.g. `variant_cdna_sequence_assembly` to `variant_sequence_assembly`, since I don't want to maintain two different terms for the same object ("variant sequence" vs. "variant cdna sequence").

**Update:** 

Found a bug in how overlap size between VariantSequences was computed and also saw some room for improvement in the assembly algorithm. Changed both of those and added VariantSequence and assembly unit tests. 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/isovar/67)
<!-- Reviewable:end -->
