### PR TITLE
Death to namedtuple base classes

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -14,4 +14,4 @@
 
 from __future__ import print_function, division, absolute_import
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/isovar/allele_reads.py
+++ b/isovar/allele_reads.py
@@ -30,12 +30,12 @@ from .default_parameters import (
 from .variant_helpers import trim_variant
 from .dataframe_builder import DataFrameBuilder
 from .string_helpers import convert_from_bytes_if_necessary, trim_N_nucleotides
-from .compact_object import CompactObject
+from .value_object import ValueObject
 
 logger = logging.getLogger(__name__)
 
 
-class AlleleRead(CompactObject):
+class AlleleRead(ValueObject):
     __slots__ = ["prefix", "allele", "suffix", "name", "sequence"]
 
     def __init__(self, prefix, allele, suffix, name):

--- a/isovar/dataframe_builder.py
+++ b/isovar/dataframe_builder.py
@@ -29,7 +29,7 @@ class DataFrameBuilder(object):
     """
     Helper class for constructing a DataFrame which always has fields
     of a variant (chr/pos/ref/alt) as well as some subset of the fields
-    from a namedtuple.
+    from a namedtuple or ValueObject.
     """
     def __init__(
             self,
@@ -47,7 +47,7 @@ class DataFrameBuilder(object):
         element_class : type
             Class of elements in this collection.
 
-        field_name : list, optional
+        field_names : list, optional
             If not given then we expect element_class to have a class member
             named '_fields' which is a list of field names.
 

--- a/isovar/locus_reads.py
+++ b/isovar/locus_reads.py
@@ -19,7 +19,6 @@ for extracting variant nucleotides.
 """
 
 from __future__ import print_function, division, absolute_import
-from collections import namedtuple
 import logging
 
 from .default_parameters import (
@@ -29,17 +28,34 @@ from .default_parameters import (
 )
 from .common import list_to_string
 from .dataframe_builder import DataFrameBuilder
-
+from .value_object import ValueObject
 
 logger = logging.getLogger(__name__)
 
-class LocusRead(namedtuple("LocusRead", [
+class LocusRead(ValueObject):
+    __slots__ = [
         "name",
         "sequence",
         "reference_positions",
         "quality_scores",
         "base0_read_position_before_variant",
-        "base0_read_position_after_variant"])):
+        "base0_read_position_after_variant"
+    ]
+
+    def __init__(
+            self,
+            name,
+            sequence,
+            reference_positions,
+            quality_scores,
+            base0_read_position_before_variant,
+            base0_read_position_after_variant):
+        self.name = name
+        self.sequence = sequence
+        self.reference_positions = reference_positions
+        self.quality_scores = quality_scores
+        self.base0_read_position_before_variant = base0_read_position_before_variant
+        self.base0_read_position_after_variant = base0_read_position_after_variant
 
     @classmethod
     def from_pysam_pileup_element(

--- a/isovar/protein_sequences.py
+++ b/isovar/protein_sequences.py
@@ -140,8 +140,8 @@ class ProteinSequence(TranslationKey):
             transcripts_supporting_protein_sequence,
             gene):
         """
-        Create a ProteinSequence object from a TranslationKey, and extra fields
-        which must be supplied in extra_kwargs.
+        Create a ProteinSequence object from a TranslationKey, along with
+        all the extra fields a ProteinSequence requires.
         """
         return cls(
             amino_acids=translation_key.amino_acids,

--- a/isovar/protein_sequences.py
+++ b/isovar/protein_sequences.py
@@ -20,7 +20,6 @@ ProteinSequence.
 """
 
 from __future__ import print_function, division, absolute_import
-from collections import namedtuple
 import logging
 
 from .common import groupby
@@ -38,24 +37,19 @@ from .translation import translate_variant_reads, Translation, TranslationKey
 from .read_helpers import group_reads_by_allele
 from .variant_helpers import trim_variant
 
-##########################
-#
-# ProteinSequence
-# ---------------
-#
-# Translated amino acid sequence aggregated across possibly multiple
-# VariantSequence and ReferenceContext objects (e.g. imagine two distinct
-# sequences which contain synonymous codons).
-#
-# This is the final result of the isovar variant->expressed peptide pipeline.
-#
-##########################
 
 logger = logging.getLogger(__name__)
 
-ProteinSequenceBase = namedtuple(
-    "ProteinSequence",
-    TranslationKey._fields + (
+
+class ProteinSequence(TranslationKey):
+    """
+    Translated amino acid sequence aggregated across possibly multiple
+    VariantSequence and ReferenceContext objects (e.g. imagine two distinct
+    sequences which contain synonymous codons).
+
+    This is the final result of the isovar variant->expressed peptide pipeline.
+    """
+    __slots__ = [
         # list of all the Translation objects which support this distinct
         # amino acid sequence
         "translations",
@@ -79,9 +73,39 @@ ProteinSequenceBase = namedtuple(
         # name of gene of the reference transcripts used in Translation
         # objects
         "gene",
-    ))
+    ]
 
-class ProteinSequence(ProteinSequenceBase):
+    def __init__(
+            self,
+            amino_acids,
+            variant_aa_interval_start,
+            variant_aa_interval_end,
+            ends_with_stop_codon,
+            frameshift,
+            translations,
+            overlapping_reads,
+            ref_reads,
+            alt_reads,
+            alt_reads_supporting_protein_sequence,
+            transcripts_overlapping_variant,
+            transcripts_supporting_protein_sequence,
+            gene):
+        self.amino_acids = amino_acids
+        self.variant_aa_interval_start = variant_aa_interval_start
+        self.variant_aa_interval_end = variant_aa_interval_end
+        self.ends_with_stop_codon = ends_with_stop_codon
+        self.frameshift = frameshift
+        self.translations = translations
+        self.overlapping_reads = overlapping_reads
+        self.ref_reads = ref_reads
+        self.alt_reads = alt_reads
+        self.alt_reads_supporting_protein_sequence = (
+            alt_reads_supporting_protein_sequence)
+        self.transcripts_overlapping_variant = transcripts_overlapping_variant
+        self.transcripts_supporting_protein_sequence = (
+            transcripts_supporting_protein_sequence)
+        self.gene = gene
+
     @classmethod
     def _summarize_translations(cls, translations):
         """
@@ -104,16 +128,37 @@ class ProteinSequence(ProteinSequenceBase):
         return unique_reads, transcript_ids, gene_names
 
     @classmethod
-    def from_translation_key(cls, translation_key, **extra_kwargs):
+    def from_translation_key(
+            cls,
+            translation_key,
+            translations,
+            overlapping_reads,
+            ref_reads,
+            alt_reads,
+            alt_reads_supporting_protein_sequence,
+            transcripts_overlapping_variant,
+            transcripts_supporting_protein_sequence,
+            gene):
         """
         Create a ProteinSequence object from a TranslationKey, and extra fields
         which must be supplied in extra_kwargs.
         """
-        values_dict = {}
-        for name in TranslationKey._fields:
-            values_dict[name] = getattr(translation_key, name)
-        values_dict.update(extra_kwargs)
-        return cls(**values_dict)
+        return cls(
+            amino_acids=translation_key.amino_acids,
+            variant_aa_interval_start=translation_key.variant_aa_interval_start,
+            variant_aa_interval_end=translation_key.variant_aa_interval_end,
+            ends_with_stop_codon=translation_key.ends_with_stop_codon,
+            frameshift=translation_key.frameshift,
+            translations=translations,
+            overlapping_reads=overlapping_reads,
+            ref_reads=ref_reads,
+            alt_reads=alt_reads,
+            alt_reads_supporting_protein_sequence=(
+                alt_reads_supporting_protein_sequence),
+            transcripts_overlapping_variant=transcripts_overlapping_variant,
+            transcripts_supporting_protein_sequence=(
+                transcripts_supporting_protein_sequence),
+            gene=gene)
 
     def ascending_sort_key(self):
         """
@@ -128,8 +173,7 @@ class ProteinSequence(ProteinSequenceBase):
         """
         return (
             len(self.alt_reads_supporting_protein_sequence),
-            min(
-                t.number_mismatches
+            min(t.number_mismatches
                 for t in self.translations),
             len(self.transcripts_supporting_protein_sequence)
         )
@@ -139,7 +183,10 @@ def sort_protein_sequences(protein_sequences):
     Sort protein sequences in decreasing order of priority
     """
     return list(
-        sorted(protein_sequences, key=ProteinSequence.ascending_sort_key, reverse=True))
+        sorted(
+            protein_sequences,
+            key=ProteinSequence.ascending_sort_key,
+            reverse=True))
 
 def reads_generator_to_protein_sequences_generator(
         variant_and_overlapping_reads_generator,

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -15,13 +15,13 @@
 from __future__ import print_function, division, absolute_import
 import logging
 
-from .compact_object import CompactObject
+from .value_object import ValueObject
 from .dna import reverse_complement_dna
 from .variant_helpers import interbase_range_affected_by_variant_on_transcript
 
 logger = logging.getLogger(__name__)
 
-class ReferenceSequenceKey(CompactObject):
+class ReferenceSequenceKey(ValueObject):
     """
     Used to identify and group the distinct sequences occurring on a set of
     transcripts overlapping a variant locus.

--- a/isovar/translation.py
+++ b/isovar/translation.py
@@ -20,7 +20,6 @@ translations.
 
 
 from __future__ import print_function, division, absolute_import
-from collections import namedtuple
 import math
 import logging
 
@@ -40,32 +39,41 @@ from .default_parameters import (
     VARIANT_SEQUENCE_ASSEMBLY,
 )
 from .dataframe_builder import dataframe_from_generator
-
+from .value_object import ValueObject
 
 logger = logging.getLogger(__name__)
 
-# TranslationKey contains fields related to a translated protein sequence
-# which should be used to combine multiple equivalent mutated amino acid
-# sequences.
-TranslationKey = namedtuple("TranslationKey", (
-    # translated sequence of a variant sequence in the ORF established
-    # by a reference context
-    "amino_acids",
-    # half-open interval coordinates for variant amino acids
-    # in the translated sequence
-    "variant_aa_interval_start",
-    "variant_aa_interval_end",
-    # did the amino acid sequence end due to a stop codon or did we
-    # just run out of sequence context around the variant?
-    "ends_with_stop_codon",
-    # was the variant a frameshift relative to the reference sequence?
-    "frameshift"))
+class TranslationKey(ValueObject):
+    """
+    TranslationKey contains fields related to a translated protein sequence
+    which should be used to combine multiple equivalent mutated amino acid
+    sequences.
+    """
+    __slots__ = [
+        # translated sequence of a variant sequence in the ORF established
+        # by a reference context
+        "amino_acids",
+        # half-open interval coordinates for variant amino acids
+        # in the translated sequence
+        "variant_aa_interval_start",
+        "variant_aa_interval_end",
+        # did the amino acid sequence end due to a stop codon or did we
+        # just run out of sequence context around the variant?
+        "ends_with_stop_codon",
+        # was the variant a frameshift relative to the reference sequence?
+        "frameshift"
+    ]
 
-class Translation(object):
+class Translation(TranslationKey):
     """
     Translated amino acid sequence of a VariantSequenceInReadingFrame for a
     particular ReferenceContext and VariantSequence.
     """
+    __slots__ = [
+        "untrimmed_variant_sequence",
+        "reference_context",
+        "variant_sequence_in_reading_frame"
+    ]
 
     def __init__(
             self,

--- a/isovar/value_object.py
+++ b/isovar/value_object.py
@@ -38,13 +38,29 @@ class MetaclassCollectSlots(type):
                 for cls in inherited_class_order))
 
 @add_metaclass(MetaclassCollectSlots)
-class CompactObject(object):
+class ValueObject(object):
     """
     Base class for objects which define their fields
     via __slots__ to decrease memory footporint and
     speed up field access.
+
+    Since a ValueObject can specified purely by a list of field names
+    and then inherits a lot of useful helper methods (e.g. hashing,
+    equality, string representation) it can act as something like
+    an algebraic datatype implementation in Python.
     """
     __slots__ = []
+
+    def __init__(self, **kwargs):
+        """
+        Default initializer for any instance of ValueObject
+        """
+        for field_name in self._fields:
+            if field_name not in kwargs:
+                raise ValueError("Missing argument '%s' to %s.__init__" % (
+                    field_name,
+                    self.__class__.__name__))
+            setattr(self, field_name, kwargs[field_name])
 
     def _values_generator(self):
         return (getattr(self, name) for name in self._fields)

--- a/isovar/variant_helpers.py
+++ b/isovar/variant_helpers.py
@@ -19,9 +19,9 @@ Helper functions for normalizing and working with genomic variants
 from __future__ import print_function, division, absolute_import
 import logging
 
+from six.moves import range
 
 logger = logging.getLogger(__name__)
-
 
 def trim_variant_fields(location, ref, alt):
     """

--- a/isovar/variant_sequence_in_reading_frame.py
+++ b/isovar/variant_sequence_in_reading_frame.py
@@ -19,16 +19,24 @@ translations.
 """
 
 from __future__ import print_function, division, absolute_import
-from collections import namedtuple
+
 import logging
 
 from six.moves import range, zip
 
 from .dna import reverse_complement_dna
+from .value_object import ValueObject
 
 logger = logging.getLogger(__name__)
 
-class VariantSequenceInReadingFrame(namedtuple("VariantSequenceInReadingFrame", (
+class VariantSequenceInReadingFrame(ValueObject):
+    """
+    A variant cDNA sequence (possibly trimmed to get rid of low coverage
+    tails) assigned to a particular strand ('+' or '-') and reading frame
+    (one of 0, +1, +2). The strand and reading frame are determined by
+    matching the cDNA sequence to a ReferenceContext.
+    """
+    __slots__ = [
         # since the reference context and variant sequence may have
         # different numbers of nucleotides before the variant, the cDNA prefix
         # gets truncated to the shortest length. To avoid having to recompute
@@ -40,11 +48,24 @@ class VariantSequenceInReadingFrame(namedtuple("VariantSequenceInReadingFrame", 
         "variant_cdna_interval_start",
         "variant_cdna_interval_end",
         "reference_cdna_sequence_before_variant",
-        "number_mismatches"))):
-    """
-    VariantSequence trimmed to have its first codon align with a reading
-    frame determined from a ReferenceContext.
-    """
+        "number_mismatches"
+    ]
+
+    def __init__(
+            self,
+            cdna_sequence,
+            offset_to_first_complete_codon,
+            variant_cdna_interval_start,
+            variant_cdna_interval_end,
+            reference_cdna_sequence_before_variant,
+            number_mismatches):
+        self.cdna_sequence = cdna_sequence
+        self.offset_to_first_complete_codon = offset_to_first_complete_codon
+        self.variant_cdna_interval_start = variant_cdna_interval_start
+        self.variant_cdna_interval_end = variant_cdna_interval_end
+        self.reference_cdna_sequence_before_variant = (
+            reference_cdna_sequence_before_variant)
+        self.number_mismatches = number_mismatches
 
     @classmethod
     def from_variant_sequence_and_reference_context(

--- a/isovar/variant_sequences.py
+++ b/isovar/variant_sequences.py
@@ -14,7 +14,6 @@
 
 from __future__ import print_function, division, absolute_import
 import logging
-from collections import namedtuple
 
 import numpy as np
 
@@ -32,14 +31,12 @@ from .default_parameters import (
 )
 from .dataframe_builder import dataframe_from_generator
 from .assembly import iterative_overlap_assembly, collapse_substrings
+from .value_object import ValueObject
 
 logger = logging.getLogger(__name__)
 
-# using this base class to define the core fields of a VariantSequence
-# but inheriting it from it to allow the addition of helper methods
-VariantSequenceBase = namedtuple(
-    "VariantSequence",
-    [
+class VariantSequence(ValueObject):
+    __slots__ = [
         # nucleotides before a variant
         "prefix",
         # nucleotide sequence of a variant
@@ -49,18 +46,15 @@ VariantSequenceBase = namedtuple(
         # since we often want to look at prefix+alt+suffix, let's cache it
         "sequence",
         # reads which were used to determine this sequences
-        "reads"])
+        "reads"
+    ]
 
-class VariantSequence(VariantSequenceBase):
-    def __new__(cls, prefix, alt, suffix, reads):
-        # construct sequence from prefix + alt + suffix
-        return VariantSequenceBase.__new__(
-            cls,
-            prefix=prefix,
-            alt=alt,
-            suffix=suffix,
-            sequence=prefix + alt + suffix,
-            reads=frozenset(reads))
+    def __init__(self, prefix, alt, suffix, reads):
+        self.prefix = prefix
+        self.alt = alt
+        self.suffix = suffix
+        self.sequence = prefix + alt + suffix
+        self.reads = frozenset(reads)
 
     def __len__(self):
         return len(self.sequence)

--- a/isovar/variant_sequences.py
+++ b/isovar/variant_sequences.py
@@ -119,12 +119,15 @@ class VariantSequence(ValueObject):
         """
         if len(reads) == 0:
             return self
-        else:
+        new_reads = self.reads.union(reads)
+        if len(new_reads) > len(self.reads):
             return VariantSequence(
                 prefix=self.prefix,
                 alt=self.alt,
                 suffix=self.suffix,
-                reads=self.reads.union(reads))
+                reads=new_reads)
+        else:
+            return self
 
     def combine(self, other_sequence):
         """

--- a/test/test_value_object.py
+++ b/test/test_value_object.py
@@ -1,0 +1,37 @@
+from isovar.value_object import ValueObject
+from nose.tools import eq_
+
+def test_no_fields_unless_specified():
+    v = ValueObject()
+    eq_(v._fields, ())
+    eq_(v._values, ())
+
+def test_default_string_repr():
+    v = ValueObject()
+    eq_(str(v), "ValueObject()")
+    eq_(repr(v), "ValueObject()")
+
+class DerivedWithoutInit(ValueObject):
+    __slots__ = ["a", "b"]
+
+def test_default_init():
+    obj = DerivedWithoutInit(a=1, b=2)
+    eq_(obj.a, 1)
+    eq_(obj.b, 2)
+
+class DerivedWithInit(ValueObject):
+    __slots__ = ["a", "b"]
+
+def test_equality_checks_class():
+    # two objects of different classes should not be equal
+    # even if their fields are the same
+    x = DerivedWithInit(a=1, b=2)
+    y = DerivedWithoutInit(a=1, b=2)
+
+    eq_(hash(x), hash(y))
+    assert x != y, "Expected %s != %s" % (x, y)
+
+def test_derived_string_repr():
+    x = DerivedWithInit(a=1, b=2)
+    eq_(str(x), "DerivedWithInit(a=1, b=2)")
+    eq_(repr(x), "DerivedWithInit(a=1, b=2)")

--- a/test/test_value_object.py
+++ b/test/test_value_object.py
@@ -22,6 +22,10 @@ def test_default_init():
 class DerivedWithInit(ValueObject):
     __slots__ = ["a", "b"]
 
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
 def test_equality_checks_class():
     # two objects of different classes should not be equal
     # even if their fields are the same


### PR DESCRIPTION
Up until recently, isovar used `namedtuple` base classes for many of its objects since this was expedient for prototyping (less code, automatic definition of basic object methods). This PR completes moving away from `namedtuple` base classes to declaring fields in `__slots__` and using a base class which is aware of slots and uses them to define all the basic objects methods. The base class in this case is more magical but all the other objects are now more explicit about which fields they contain and have explicitly defined `__init__` methods. The latter should be helpful if @julia326 ever wants to move this code to not use a magical base class at all. 

Changes:
* Renamed `CompactObject` to `ValueObject` since its main purpose is making objects into functional-style value types. 
* `LocusRead`, `ProteinSequence`, `TranslationKey`, `VariantSequenceInReadingFrame` now inherit from `ValueObject`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/isovar/71)
<!-- Reviewable:end -->
