### PR TITLE
Remove Python 2 compat: six, cached-property, __future__ imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,9 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 
 from .allele_read import AlleleRead

--- a/isovar/alignment_score.py
+++ b/isovar/alignment_score.py
@@ -15,9 +15,6 @@
 Sequence alignment helpers
 """
 
-from __future__ import print_function, division, absolute_import
-
-
 def alignment_score(a, b, min_subsequence_length=1):
     """
     Number of mismatches between all two input sequences, allows

--- a/isovar/allele_read.py
+++ b/isovar/allele_read.py
@@ -15,7 +15,6 @@ Reads overlapping a locus of interest split into prefix,
 allele (ref, alt, or otherwise), and suffix portions
 """
 
-from __future__ import print_function, division, absolute_import
 import logging
 
 from .string_helpers import convert_from_bytes_if_necessary, trim_N_nucleotides

--- a/isovar/assembly.py
+++ b/isovar/assembly.py
@@ -10,11 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from collections import defaultdict
-
-from six.moves import range
 
 from .default_parameters import MIN_VARIANT_SEQUENCE_ASSEMBLY_OVERLAP_SIZE
 from .logging import get_logger

--- a/isovar/cli/__init__.py
+++ b/isovar/cli/__init__.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import
-
 from .main_args import make_isovar_arg_parser, run_isovar_from_parsed_args
 from .protein_sequence_args import protein_sequence_creator_from_args
 from .rna_args import read_collector_from_args

--- a/isovar/cli/filter_args.py
+++ b/isovar/cli/filter_args.py
@@ -14,8 +14,6 @@
 Common command-line arguments for filtering Isovar results
 """
 
-from __future__ import print_function, division, absolute_import
-
 from collections import OrderedDict
 
 from ..default_parameters import (

--- a/isovar/cli/isovar_allele_counts.py
+++ b/isovar/cli/isovar_allele_counts.py
@@ -14,7 +14,6 @@
 Prints number of reads supporting ref, alt, and other alleles at variant loci.
 """
 
-from __future__ import print_function, division, absolute_import
 import sys
 
 from ..logging import get_logger

--- a/isovar/cli/isovar_allele_reads.py
+++ b/isovar/cli/isovar_allele_reads.py
@@ -14,7 +14,6 @@
 Prints names and sequences of reads overlapping a given set of variants.
 """
 
-from __future__ import print_function, division, absolute_import
 import sys
 
 from ..logging import get_logger

--- a/isovar/cli/isovar_main.py
+++ b/isovar/cli/isovar_main.py
@@ -15,8 +15,6 @@ Primary Isovar command, used to collect information about variants,
 the RNA reads which overlap and protein sequences which can be constructed
 from reads that support the variant.
 """
-from __future__ import print_function, division, absolute_import
-
 import sys
 
 

--- a/isovar/cli/isovar_protein_sequences.py
+++ b/isovar/cli/isovar_protein_sequences.py
@@ -16,7 +16,6 @@ RNAseq BAM from the same sample. Combine synonymous translations and assign
 a read count to each protein sequence.
 """
 
-from __future__ import print_function, division, absolute_import
 import sys
 
 

--- a/isovar/cli/isovar_reference_contexts.py
+++ b/isovar/cli/isovar_reference_contexts.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 import sys
 
 from ..logging import get_logger

--- a/isovar/cli/isovar_translations.py
+++ b/isovar/cli/isovar_translations.py
@@ -15,7 +15,6 @@ Translate each non-synonymous coding variants into possible mutant protein
 sequences using an RNAseq BAM from the same tissuie.
 """
 
-from __future__ import print_function, division, absolute_import
 import sys
 
 from ..logging import get_logger

--- a/isovar/cli/isovar_variant_reads.py
+++ b/isovar/cli/isovar_variant_reads.py
@@ -14,7 +14,6 @@
 Prints names and sequences of reads supporting a given set of variants.
 """
 
-from __future__ import print_function, division, absolute_import
 import sys
 
 from ..logging import get_logger

--- a/isovar/cli/isovar_variant_sequences.py
+++ b/isovar/cli/isovar_variant_sequences.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 import sys
 
 from ..logging import get_logger

--- a/isovar/cli/main_args.py
+++ b/isovar/cli/main_args.py
@@ -14,8 +14,6 @@
 Create parser and run Isovar from parsed args
 """
 
-from __future__ import print_function, division, absolute_import
-
 from varcode.cli import variant_collection_from_args
 
 from ..main import run_isovar

--- a/isovar/cli/output_args.py
+++ b/isovar/cli/output_args.py
@@ -15,9 +15,6 @@ Common helper functions for writing CSV output files, shared by all
 the CLI commands
 """
 
-from __future__ import print_function, division, absolute_import
-
-
 def add_output_args(
         parser,
         filename="output.csv",

--- a/isovar/cli/protein_sequence_args.py
+++ b/isovar/cli/protein_sequence_args.py
@@ -11,8 +11,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import
-
 from ..default_parameters import MAX_PROTEIN_SEQUENCES_PER_VARIANT
 from ..main import ProteinSequenceCreator
 from ..dataframe_helpers import protein_sequences_generator_to_dataframe

--- a/isovar/cli/reference_context_args.py
+++ b/isovar/cli/reference_context_args.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from varcode.cli.variant_args import (
     make_variants_parser,
     variant_collection_from_args

--- a/isovar/cli/rna_args.py
+++ b/isovar/cli/rna_args.py
@@ -14,8 +14,6 @@
 Common command-line arguments for all Isovar commands which use RNA
 """
 
-from __future__ import print_function, division, absolute_import
-
 from pysam import AlignmentFile
 
 from varcode.cli import make_variants_parser, variant_collection_from_args

--- a/isovar/cli/translation_args.py
+++ b/isovar/cli/translation_args.py
@@ -15,8 +15,6 @@ Common command-line arguments for all Isovar commands which translate
 cDNA into protein sequences.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from ..default_parameters import (
     MIN_TRANSCRIPT_PREFIX_LENGTH,
     MAX_REFERENCE_TRANSCRIPT_MISMATCHES,

--- a/isovar/cli/variant_sequences_args.py
+++ b/isovar/cli/variant_sequences_args.py
@@ -11,8 +11,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import
-
 from ..default_parameters import (
     MIN_VARIANT_SEQUENCE_COVERAGE,
     VARIANT_SEQUENCE_LENGTH,

--- a/isovar/common.py
+++ b/isovar/common.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from collections import defaultdict
 import numpy as np
 

--- a/isovar/dataframe_builder.py
+++ b/isovar/dataframe_builder.py
@@ -10,14 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 from collections import OrderedDict
-from six import integer_types, text_type, binary_type
 
 from varcode import Variant
 import pandas as pd
 
-VALID_ELEMENT_TYPES = integer_types + (text_type, binary_type, float, bool)
+VALID_ELEMENT_TYPES = (int, str, bytes, float, bool)
 
 # values of these types are automatically converted to their size or length
 # unless some other conversion function is provided

--- a/isovar/dataframe_helpers.py
+++ b/isovar/dataframe_helpers.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 import pandas as pd
 
 from .allele_read import AlleleRead

--- a/isovar/default_parameters.py
+++ b/isovar/default_parameters.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 """
 Gathered all the default function parameters in a single module, so that these
 values can be easily shared between modules and also between commandline

--- a/isovar/dna.py
+++ b/isovar/dna.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 """
 This module implements basic DNA functionality in Python strings to
 to avoid having to depend on a bigger library such as BioPython.

--- a/isovar/effect_prediction.py
+++ b/isovar/effect_prediction.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from varcode.effects.effect_classes import ExonicSpliceSite, CodingMutation
 
 from .logging import get_logger

--- a/isovar/filtering.py
+++ b/isovar/filtering.py
@@ -14,8 +14,6 @@
 Functions used to annotate IsovarResult objects with filters.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from collections import OrderedDict
 import operator
 

--- a/isovar/genetic_code.py
+++ b/isovar/genetic_code.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 """
 GeneticCode objects contain the rules for translating cDNA into a protein
 sequence: the set of valid start and stop codons, as well as which

--- a/isovar/isovar_result.py
+++ b/isovar/isovar_result.py
@@ -18,11 +18,9 @@ IsovarResult is a collection of all information gathered about a variant
 and any protein sequences which were successfully translated for it.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from collections import OrderedDict
 
-from cached_property import cached_property
+from functools import cached_property
 
 from .common import safediv
 from .alignment_score import alignment_score

--- a/isovar/locus_read.py
+++ b/isovar/locus_read.py
@@ -16,8 +16,6 @@ a variant locus which includes offsets into the read sequence & qualities
 for extracting variant nucleotides.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from .value_object import ValueObject
 
 

--- a/isovar/logging.py
+++ b/isovar/logging.py
@@ -11,8 +11,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import
-
 import logging
 import logging.config
 import pkg_resources

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -11,9 +11,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import
-
-from six import string_types
 from varcode import load_vcf
 from pysam import AlignmentFile
 from collections import OrderedDict
@@ -133,10 +130,10 @@ def run_isovar(
     `protein_sequences` field of the IsovarVar result will be empty
     if no sequences could be determined.
     """
-    if isinstance(variants, string_types):
+    if isinstance(variants, str):
         variants = load_vcf(variants)
 
-    if isinstance(alignment_file, string_types):
+    if isinstance(alignment_file, str):
         alignment_file = AlignmentFile(
             alignment_file,
             threads=decompression_threads)

--- a/isovar/phasing.py
+++ b/isovar/phasing.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from collections import defaultdict, Counter
 
 from .default_parameters import MIN_SHARED_FRAGMENTS_FOR_PHASING

--- a/isovar/protein_sequence.py
+++ b/isovar/protein_sequence.py
@@ -16,8 +16,6 @@ ProteinSequence is a representation of a translated coding sequence,
 associated with its supporting (and non-supporting but overlapping) RNA reads.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from .common import normalize_base0_range_indices
 from .translation_key import TranslationKey
 from .translation import Translation

--- a/isovar/protein_sequence_creator.py
+++ b/isovar/protein_sequence_creator.py
@@ -11,8 +11,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import
-
 from .default_parameters import (
     MIN_TRANSCRIPT_PREFIX_LENGTH,
     MAX_REFERENCE_TRANSCRIPT_MISMATCHES,

--- a/isovar/protein_sequence_helpers.py
+++ b/isovar/protein_sequence_helpers.py
@@ -17,8 +17,6 @@ this module aggregates equivalent Translation objects into a single
 ProteinSequence.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from .common import groupby
 from .logging import get_logger
 from .protein_sequence import ProteinSequence

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -10,10 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
-from six import integer_types
-
 from .default_parameters import (
     USE_SECONDARY_ALIGNMENTS,
     USE_DUPLICATE_READS,

--- a/isovar/read_evidence.py
+++ b/isovar/read_evidence.py
@@ -16,8 +16,6 @@ Collect AlleleReads overlapping each variant grouped by whether
 they support the reference, somatic allele, or some other allele.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from .allele_read_helpers import split_reads_into_ref_alt_other
 from .variant_helpers import trim_variant
 from .value_object import ValueObject

--- a/isovar/reference_coding_sequence_key.py
+++ b/isovar/reference_coding_sequence_key.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .logging import get_logger
 from .reference_sequence_key import ReferenceSequenceKey
 from .variant_helpers import interbase_range_affected_by_variant_on_transcript

--- a/isovar/reference_context.py
+++ b/isovar/reference_context.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .reference_coding_sequence_key import ReferenceCodingSequenceKey
 from .logging import get_logger
 

--- a/isovar/reference_context_helpers.py
+++ b/isovar/reference_context_helpers.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from collections import defaultdict
 
 

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .logging import get_logger
 from .value_object import ValueObject
 from .variant_helpers import (

--- a/isovar/string_helpers.py
+++ b/isovar/string_helpers.py
@@ -11,8 +11,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import
-
 from .logging import get_logger
 
 logger = get_logger(__name__)

--- a/isovar/translation.py
+++ b/isovar/translation.py
@@ -17,8 +17,6 @@ translations.
 """
 
 
-from __future__ import print_function, division, absolute_import
-
 from .logging import get_logger
 from .translation_key import TranslationKey
 

--- a/isovar/translation_helpers.py
+++ b/isovar/translation_helpers.py
@@ -16,8 +16,6 @@ Helper functions used for creating translating a variant's cDNA sequence
 into a particular reading frame.
 """
 
-from __future__ import print_function, division, absolute_import
-
 import math
 
 def find_mutant_amino_acid_interval(

--- a/isovar/translation_key.py
+++ b/isovar/translation_key.py
@@ -17,8 +17,6 @@ translations.
 """
 
 
-from __future__ import print_function, division, absolute_import
-
 from .logging import get_logger
 from .value_object import ValueObject
 

--- a/isovar/value_object.py
+++ b/isovar/value_object.py
@@ -10,10 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 from itertools import chain
-from six import add_metaclass, string_types
-from six.moves import zip
 
 
 class MetaclassCollectSlots(type):
@@ -37,8 +34,7 @@ class MetaclassCollectSlots(type):
                 for cls in inherited_class_order))
 
 
-@add_metaclass(MetaclassCollectSlots)
-class ValueObject(object):
+class ValueObject(metaclass=MetaclassCollectSlots):
     """
     Base class for objects which define their fields
     via __slots__ to decrease memory footporint and
@@ -73,7 +69,7 @@ class ValueObject(object):
         field_strings = []
         for name, value in zip(self._fields, self._values):
             format_string = (
-                "%s='%s'" if isinstance(value, string_types) else "%s=%s")
+                "%s='%s'" if isinstance(value, str) else "%s=%s")
             field_strings.append(format_string % (name, value))
         return "%s(%s)" % (
             self.__class__.__name__,

--- a/isovar/variant_helpers.py
+++ b/isovar/variant_helpers.py
@@ -14,9 +14,6 @@
 Helper functions for normalizing and working with genomic variants
 """
 
-from __future__ import print_function, division, absolute_import
-
-from six.moves import range
 from .logging import get_logger
 from .dna import reverse_complement_dna
 

--- a/isovar/variant_orf.py
+++ b/isovar/variant_orf.py
@@ -16,10 +16,6 @@ the reading frames of annotated reference transcripts to create candidate
 translations.
 """
 
-from __future__ import print_function, division, absolute_import
-
-from six.moves import zip
-
 from .dna import reverse_complement_dna
 from .logging import get_logger
 from .value_object import ValueObject

--- a/isovar/variant_orf_helpers.py
+++ b/isovar/variant_orf_helpers.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .logging import get_logger
 from .variant_orf import VariantORF
 

--- a/isovar/variant_sequence.py
+++ b/isovar/variant_sequence.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 

--- a/isovar/variant_sequence_creator.py
+++ b/isovar/variant_sequence_creator.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .allele_read_helpers import get_single_allele_from_reads
 from .assembly import iterative_overlap_assembly
 from .default_parameters import (

--- a/isovar/variant_sequence_helpers.py
+++ b/isovar/variant_sequence_helpers.py
@@ -15,8 +15,6 @@ Helper functions for constructing and filtering VariantSequence objects
 from reads overlapping a variant locus.
 """
 
-from __future__ import print_function, division, absolute_import
-
 from .allele_read_helpers import group_unique_sequences
 from .assembly import collapse_substrings
 from .logging import get_logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-six>=1.9.0
 pylint>=1.4.4
 pyensembl>=1.5.0
 varcode>=0.9.0
 pandas>=0.23.0
 pysam>=0.15.2
 nose>=1.3.3
-cached_property>=1.5.1
 psutil

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import (absolute_import,)
-
 import os
 import logging
 import re
@@ -56,13 +54,12 @@ if __name__ == '__main__':
             'Programming Language :: Python',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
         ],
+        python_requires='>=3.9',
         install_requires=[
-            'six',
             'pysam>=0.15.2',
             'pandas',
             'varcode>=0.9.0',
             'pyensembl>=1.5.0',
-            'cached_property>=1.5.1',
             'psutil',
         ],
         long_description=readme_markdown,

--- a/tests/test_dataframe_builder.py
+++ b/tests/test_dataframe_builder.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 from collections import namedtuple, OrderedDict
 from nose.tools import eq_
 from varcode import Variant

--- a/tests/test_reference_sequence_key.py
+++ b/tests/test_reference_sequence_key.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from varcode import Variant
 from .common import eq_ 
 


### PR DESCRIPTION
## Summary
- Remove `six` dependency — replace with Python 3 builtins (`str`, `int`, `bytes`, `range`, `zip`, metaclass syntax)
- Remove `cached-property` — use `functools.cached_property` (stdlib since 3.8)
- Remove `from __future__ import` statements from all files
- Add `python_requires='>=3.9'`
- Bump version to 1.4.0

## Test plan
- [ ] CI passes on Python 3.9, 3.10, 3.11