### PR TITLE
Fix #131: drop reads with N at variant locus

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 
 from .allele_read import AlleleRead

--- a/isovar/allele_read.py
+++ b/isovar/allele_read.py
@@ -93,6 +93,8 @@ class AlleleRead(ValueObject):
             logger.debug(
                 "Skipping read '%s', found N nucleotides at variant locus",
                 read_name)
+            return None
+
         prefix = convert_from_bytes_if_necessary(sequence[:read_base0_start_inclusive])
         suffix = convert_from_bytes_if_necessary(sequence[read_base0_end_exclusive:])
 

--- a/tests/test_allele_reads.py
+++ b/tests/test_allele_reads.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from isovar.allele_read import AlleleRead
+from isovar.allele_read_helpers import allele_reads_from_locus_reads
 from isovar.locus_read import LocusRead
 from isovar.read_collector import ReadCollector
 from varcode import Variant
@@ -40,6 +41,38 @@ def test_allele_read_from_single_read_at_locus_trim_N_nucleotides():
     print(allele_read)
     expected = AlleleRead(prefix="", allele="A", suffix="T", name="dummy")
     eq_(allele_read, expected)
+
+
+def test_allele_read_from_locus_with_N_in_allele_returns_none():
+    # Ambiguous base at the variant locus itself must not become an
+    # AlleleRead; callers rely on None to drop the read.
+    read_at_locus = make_read_at_locus(prefix="ACGT", alt="N", suffix="ACGT")
+    allele_read = AlleleRead.from_locus_read(read_at_locus)
+    assert allele_read is None, \
+        "Expected None for a read with N at the variant locus, got %s" % (
+            allele_read,)
+
+
+def test_allele_read_from_locus_with_N_inside_multibase_allele_returns_none():
+    read_at_locus = make_read_at_locus(prefix="ACGT", alt="ANA", suffix="ACGT")
+    allele_read = AlleleRead.from_locus_read(read_at_locus)
+    assert allele_read is None, \
+        "Expected None for a multi-base allele containing N, got %s" % (
+            allele_read,)
+
+
+def test_allele_reads_with_N_at_locus_dropped_from_helpers():
+    # allele_reads_from_locus_reads should silently drop reads with N at the
+    # variant locus instead of emitting AlleleReads whose allele contains N.
+    good = make_read_at_locus(prefix="ACGT", alt="A", suffix="ACGT", name="good")
+    bad = make_read_at_locus(prefix="ACGT", alt="N", suffix="ACGT", name="bad")
+    allele_reads = allele_reads_from_locus_reads([good, bad])
+    assert len(allele_reads) == 1, \
+        "Expected 1 AlleleRead after dropping N-containing read, got %d: %s" % (
+            len(allele_reads), allele_reads)
+    assert "N" not in allele_reads[0].allele, \
+        "Surviving AlleleRead should not have N in allele, got '%s'" % (
+            allele_reads[0].allele,)
 
 
 def test_allele_read_insertion():


### PR DESCRIPTION
## Summary
- `AlleleRead.from_locus_read` logged "Skipping read" when it saw an `N` at the variant locus but then returned the `AlleleRead` anyway. Those reads then counted toward ref/alt/other grouping. Added the missing `return None` so behavior matches the log.
- Added three tests: single-base N allele returns None, multi-base allele containing N returns None, and helper `allele_reads_from_locus_reads` drops the N-read while keeping valid reads.
- Bumped version to 1.4.2.

Fixes #131

## Test plan
- [x] `./test.sh` passes (147/144 — three new tests)
- [x] `./lint.sh` passes