### PR TITLE
Fix #127: TypeError when mapping_quality is None

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.4"
+__version__ = "1.4.5"
 
 
 from .allele_read import AlleleRead

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -97,9 +97,12 @@ class ReadCollector(object):
 
         mapping_quality = pysam_aligned_segment.mapping_quality
 
-        if self.min_mapping_quality > 0 and (mapping_quality is None):
-            logger.debug("Skipping read '%s' due to missing MAPQ" % name)
-            return None
+        if mapping_quality is None:
+            if self.min_mapping_quality > 0:
+                logger.debug("Skipping read '%s' due to missing MAPQ" % name)
+                return None
+            else:
+                mapping_quality = 0
         elif mapping_quality < self.min_mapping_quality:
             logger.debug(
                 "Skipping read '%s' due to low MAPQ: %d < %d",

--- a/tests/test_locus_reads.py
+++ b/tests/test_locus_reads.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock
+
 from varcode import Variant
 
 from isovar.locus_read import LocusRead
@@ -235,3 +237,63 @@ def test_locus_reads_dataframe():
         base0_end=45802539)
     print(df)
     eq_(len(df), n_reads_expected)
+
+
+def _make_mock_pysam_read_with_none_mapq():
+    """
+    Create a mock pysam read whose mapping_quality is None.
+
+    pysam.AlignedSegment does not allow setting mapping_quality to None
+    directly, so we use a MagicMock instead.
+    """
+    real_read = make_pysam_read(seq="ACCGTG", cigar="6M", mdtag="3G2")
+    mock_read = MagicMock()
+    mock_read.query_name = real_read.query_name
+    mock_read.query_sequence = real_read.query_sequence
+    mock_read.query_qualities = real_read.query_qualities
+    mock_read.is_secondary = False
+    mock_read.is_duplicate = False
+    mock_read.is_unmapped = False
+    mock_read.get_reference_positions.return_value = list(range(6))
+    mock_read.mapping_quality = None
+    return mock_read
+
+
+def test_locus_read_none_mapq_with_min_mapping_quality_zero():
+    """
+    When min_mapping_quality=0, a read with mapping_quality=None should NOT
+    be skipped (0 means accept everything). The None should be treated as 0.
+
+    Regression test for GitHub issue #127.
+    """
+    mock_read = _make_mock_pysam_read_with_none_mapq()
+    read_collector = ReadCollector(min_mapping_quality=0)
+    result = read_collector.locus_read_from_pysam_aligned_segment(
+        mock_read,
+        base0_start_inclusive=3,
+        base0_end_exclusive=4,
+    )
+    assert result is not None, (
+        "Expected read with mapping_quality=None to be accepted when "
+        "min_mapping_quality=0, but it was skipped"
+    )
+
+
+def test_locus_read_none_mapq_with_min_mapping_quality_nonzero():
+    """
+    When min_mapping_quality > 0, a read with mapping_quality=None should
+    be skipped.
+
+    Regression test for GitHub issue #127.
+    """
+    mock_read = _make_mock_pysam_read_with_none_mapq()
+    read_collector = ReadCollector(min_mapping_quality=1)
+    result = read_collector.locus_read_from_pysam_aligned_segment(
+        mock_read,
+        base0_start_inclusive=3,
+        base0_end_exclusive=4,
+    )
+    assert result is None, (
+        "Expected read with mapping_quality=None to be skipped when "
+        "min_mapping_quality=1, but it was accepted"
+    )


### PR DESCRIPTION
## Summary
- Guard on `mapping_quality is None` first, before any numeric comparison.
- When `min_mapping_quality == 0`, treat `None` MAPQ as `0` instead of crashing.
- Two tests with mock pysam reads: None MAPQ accepted at threshold=0, skipped at threshold=1.
- Bumped version to 1.4.5.

Fixes #127

## Test plan
- [x] `./test.sh` passes (154 tests)
- [x] `./lint.sh` passes