### PR TITLE
Fix #126: self-subtraction typo in insertion-locus branch

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.5"
+__version__ = "1.4.6"
 
 
 from .allele_read import AlleleRead

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -199,7 +199,7 @@ class ReadCollector(object):
             else:
                 return None
 
-            if read_base0_after_insertion - read_base0_after_insertion == 1:
+            if read_base0_after_insertion - read_base0_before_insertion == 1:
                 read_base0_start_inclusive = read_base0_end_exclusive = (
                     read_base0_before_insertion + 1
                 )

--- a/tests/test_locus_reads.py
+++ b/tests/test_locus_reads.py
@@ -297,3 +297,50 @@ def test_locus_read_none_mapq_with_min_mapping_quality_nonzero():
         "Expected read with mapping_quality=None to be skipped when "
         "min_mapping_quality=1, but it was accepted"
     )
+
+
+def test_locus_read_insertion_locus_no_insertion_in_read():
+    """
+    When an insertion variant is queried (reference_interval_size == 0) but the
+    read does NOT carry the insertion, the read positions flanking the locus
+    should be adjacent (differ by 1) and the returned LocusRead should have
+    an empty read interval (start == end).
+
+    Regression test for GitHub issue #126 — previously the code compared
+    read_base0_after_insertion to itself instead of read_base0_before_insertion,
+    making the adjacent-positions branch dead.
+    """
+    # Reference: ACCTTG (positions 0-5). Insertion locus between pos 3 and 4.
+    # This read has NO insertion — reference positions are contiguous.
+    pysam_read = make_pysam_read(seq="ACCTTG", cigar="6M", mdtag="6")
+    read_collector = ReadCollector()
+    result = read_collector.locus_read_from_pysam_aligned_segment(
+        pysam_read,
+        base0_start_inclusive=4,
+        base0_end_exclusive=4,
+    )
+    assert result is not None, "Read without insertion should still be returned"
+    eq_(result.read_base0_start_inclusive, 4)
+    eq_(result.read_base0_end_exclusive, 4)
+
+
+def test_locus_read_insertion_locus_with_insertion_in_read():
+    """
+    When an insertion variant is queried (reference_interval_size == 0) and the
+    read DOES carry the insertion, the returned LocusRead should have a
+    non-empty read interval spanning the inserted bases.
+
+    Companion to the test above to verify the else-branch still works.
+    """
+    # Reference: ACCTTG. Insertion of G between pos 3 and 4.
+    # Read: ACCTGTG — 4M1I2M — positions [0,1,2,3,None,4,5]
+    pysam_read = make_pysam_read(seq="ACCTGTG", cigar="4M1I2M", mdtag="6")
+    read_collector = ReadCollector()
+    result = read_collector.locus_read_from_pysam_aligned_segment(
+        pysam_read,
+        base0_start_inclusive=4,
+        base0_end_exclusive=4,
+    )
+    assert result is not None, "Read with insertion should be returned"
+    eq_(result.read_base0_start_inclusive, 4)
+    eq_(result.read_base0_end_exclusive, 5)


### PR DESCRIPTION
## Summary
- Fixed `read_base0_after_insertion - read_base0_after_insertion` → `read_base0_after_insertion - read_base0_before_insertion`
- Two new tests: insertion locus without insertion (exercises the now-reachable if-branch), insertion locus with insertion (exercises else-branch).
- Bumped version to 1.4.6.

Fixes #126

## Test plan
- [x] `./test.sh` passes (156 tests)
- [x] `./lint.sh` passes