### PR TITLE
Fix #136: replace mutable default arguments with None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ target/
 # PyCharm
 .idea/
 vcs.xml
+.claude/

--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.6"
+__version__ = "1.4.7"
 
 
 from .allele_read import AlleleRead

--- a/isovar/dataframe_builder.py
+++ b/isovar/dataframe_builder.py
@@ -32,10 +32,10 @@ class DataFrameBuilder(object):
             self,
             element_class,
             field_names=None,
-            exclude=set([]),
-            converters={},
-            rename_dict={},
-            extra_column_fns={},
+            exclude=None,
+            converters=None,
+            rename_dict=None,
+            extra_column_fns=None,
             variant_columns=True,
             convert_collections_to_size=True):
         """
@@ -77,6 +77,14 @@ class DataFrameBuilder(object):
             then collection values cause a runtime error.
         """
         self.element_class = element_class
+        if exclude is None:
+            exclude = set()
+        if converters is None:
+            converters = {}
+        if rename_dict is None:
+            rename_dict = {}
+        if extra_column_fns is None:
+            extra_column_fns = {}
         self.rename_dict = rename_dict
         self.converters = converters
         self.variant_columns = variant_columns

--- a/isovar/filtering.py
+++ b/isovar/filtering.py
@@ -103,7 +103,7 @@ def evaluate_boolean_filters(isovar_result, filter_flags):
 def evaluate_filters(
         isovar_result,
         filter_thresholds,
-        filter_flags=[]):
+        filter_flags=None):
     """
     Creates a dictionary whose keys are named of different
     filter conditions and values are booleans, where True
@@ -133,6 +133,8 @@ def evaluate_filters(
     Dictionary of filter names mapped to boolean value indicating
     whether this locus passed the filter.
     """
+    if filter_flags is None:
+        filter_flags = []
     filter_values_dict = evaluate_boolean_filters(isovar_result, filter_flags)
     filter_values_dict.update(
         evaluate_threshold_filters(isovar_result, filter_thresholds))
@@ -141,8 +143,8 @@ def evaluate_filters(
 
 def apply_filters(
         isovar_result,
-        filter_thresholds={},
-        filter_flags=[]):
+        filter_thresholds=None,
+        filter_flags=None):
     """
     Given an IsovarResult object, evaluates given filters
     for each object, and returns a copy of the IsovarResult with new fiter
@@ -168,6 +170,10 @@ def apply_filters(
 
     Returns IsovarResult
     """
+    if filter_thresholds is None:
+        filter_thresholds = {}
+    if filter_flags is None:
+        filter_flags = []
     filter_values = OrderedDict(isovar_result.filter_values.items())
     new_filter_values = evaluate_filters(
         isovar_result,

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -77,8 +77,8 @@ def run_isovar(
         transcript_id_whitelist=None,
         read_collector=None,
         protein_sequence_creator=None,
-        filter_thresholds=DEFAULT_FILTER_THRESHOLDS,
-        filter_flags=DEFAULT_FILTER_FLAGS,
+        filter_thresholds=None,
+        filter_flags=None,
         min_shared_fragments_for_phasing=MIN_SHARED_FRAGMENTS_FOR_PHASING,
         decompression_threads=1):
     """
@@ -130,6 +130,12 @@ def run_isovar(
     `protein_sequences` field of the IsovarVar result will be empty
     if no sequences could be determined.
     """
+    if filter_thresholds is None:
+        filter_thresholds = OrderedDict(DEFAULT_FILTER_THRESHOLDS)
+
+    if filter_flags is None:
+        filter_flags = list(DEFAULT_FILTER_FLAGS)
+
     if isinstance(variants, str):
         variants = load_vcf(variants)
 


### PR DESCRIPTION
## Summary
- `run_isovar`: `filter_thresholds` and `filter_flags` now default to None (copy created inside).
- `apply_filters` / `evaluate_filters`: same treatment.
- `DataFrameBuilder.__init__`: `exclude`, `converters`, `rename_dict`, `extra_column_fns` now default to None.
- Bumped version to 1.4.7.

Fixes #136

## Test plan
- [x] `./test.sh` passes (156 tests)
- [x] `./lint.sh` passes