### PR TITLE
Fix #137: replace deprecated logger.warn() with logger.warning()

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.7"
+__version__ = "1.4.8"
 
 
 from .allele_read import AlleleRead

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -88,11 +88,11 @@ class ReadCollector(object):
         name = pysam_aligned_segment.query_name
 
         if name is None:
-            logger.warn("Read missing name at position %d", base0_start_inclusive + 1)
+            logger.warning("Read missing name at position %d", base0_start_inclusive + 1)
             return None
 
         if pysam_aligned_segment.is_unmapped:
-            logger.warn("How did we get unmapped read '%s' in a pileup?", name)
+            logger.warning("How did we get unmapped read '%s' in a pileup?", name)
             return None
 
         mapping_quality = pysam_aligned_segment.mapping_quality
@@ -115,16 +115,16 @@ class ReadCollector(object):
         sequence = pysam_aligned_segment.query_sequence
 
         if sequence is None:
-            logger.warn("Skipping read '%s' due to missing sequence" % name)
+            logger.warning("Skipping read '%s' due to missing sequence" % name)
             return None
 
         base_qualities = pysam_aligned_segment.query_qualities
 
         if base_qualities is None:
-            logger.warn("Skipping read '%s' due to missing base qualities" % name)
+            logger.warning("Skipping read '%s' due to missing base qualities" % name)
             return None
         elif len(base_qualities) != len(sequence):
-            logger.warn(
+            logger.warning(
                 "Skipping read '%s' due to mismatch in length of sequence (%d) and qualities (%d)"
                 % (name, len(sequence), len(base_qualities))
             )
@@ -140,7 +140,7 @@ class ReadCollector(object):
         )
 
         if len(base0_reference_positions) != len(base_qualities):
-            logger.warn(
+            logger.warning(
                 "Skipping read '%s' due to mismatch in length of positions (%d) and qualities (%d)"
                 % (name, len(base0_reference_positions), len(base_qualities))
             )

--- a/isovar/reference_sequence_key.py
+++ b/isovar/reference_sequence_key.py
@@ -68,7 +68,7 @@ class ReferenceSequenceKey(ValueObject):
         full_transcript_sequence = transcript.sequence
 
         if full_transcript_sequence is None:
-            logger.warn(
+            logger.warning(
                 "Expected transcript %s (overlapping %s) to have sequence",
                 transcript.name,
                 variant)
@@ -88,7 +88,7 @@ class ReferenceSequenceKey(ValueObject):
                 variant=variant,
                 strand=transcript.strand,
                 ref_seq_on_transcript=reference_cdna_at_variant):
-            logger.warn(
+            logger.warning(
                 "Variant %s doesn't match reference sequence on transcript %s: "
                 "may span splice junction",
                 variant,
@@ -97,7 +97,7 @@ class ReferenceSequenceKey(ValueObject):
 
         if len(full_transcript_sequence) < 6:
             # need at least 6 nucleotides for a start and stop codon
-            logger.warn(
+            logger.warning(
                 "Sequence of %s (overlapping %s) too short: %d",
                 transcript,
                 variant,

--- a/isovar/variant_sequence.py
+++ b/isovar/variant_sequence.py
@@ -148,7 +148,7 @@ class VariantSequence(ValueObject):
         then returns None.
         """
         if other_sequence.alt != self.alt:
-            logger.warn(
+            logger.warning(
                 "Cannot combine %s and %s with mismatching alt sequences",
                 self,
                 other_sequence)


### PR DESCRIPTION
## Summary
- Renamed all `logger.warn(...)` calls to `logger.warning(...)` across `read_collector.py`, `variant_sequence.py`, and `reference_sequence_key.py`.
- Bumped version to 1.4.8.

Fixes #137

## Test plan
- [x] `./test.sh` passes (156 tests, warnings dropped from 5→4)
- [x] `./lint.sh` passes