### PR TITLE
Fix #134: expose --use-soft-clipped-bases in CLI

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.8"
+__version__ = "1.4.9"
 
 
 from .allele_read import AlleleRead

--- a/isovar/cli/rna_args.py
+++ b/isovar/cli/rna_args.py
@@ -33,6 +33,7 @@ def add_rna_args(
         --min-mapping-quality
         --use-duplicate-reads
         --drop-secondary-alignments
+        --use-soft-clipped-bases
     """
     rna_group = parser.add_argument_group("RNA")
     rna_group.add_argument(
@@ -61,6 +62,14 @@ def add_rna_args(
         help=(
             "By default, secondary alignments are included in reads, "
             "use this option to instead only use primary alignments."))
+
+    rna_group.add_argument(
+        "--use-soft-clipped-bases",
+        default=False,
+        action="store_true",
+        help=(
+            "By default, soft-clipped bases at the ends of reads are excluded. "
+            "Use this option to include them."))
 
     rna_group.add_argument(
         "--num-rna-decompression-threads",
@@ -104,7 +113,8 @@ def read_collector_from_args(args):
     return ReadCollector(
         min_mapping_quality=args.min_mapping_quality,
         use_duplicate_reads=args.use_duplicate_reads,
-        use_secondary_alignments=not args.drop_secondary_alignments)
+        use_secondary_alignments=not args.drop_secondary_alignments,
+        use_soft_clipped_bases=args.use_soft_clipped_bases)
 
 
 def read_evidence_generator_from_args(args):

--- a/tests/test_argparser_helpers.py
+++ b/tests/test_argparser_helpers.py
@@ -1,5 +1,8 @@
 from .common import eq_
-from isovar.cli.rna_args import make_rna_reads_arg_parser
+from isovar.cli.rna_args import (
+    make_rna_reads_arg_parser,
+    read_collector_from_args,
+)
 from isovar.cli.reference_context_args import add_reference_context_args
 from isovar.cli.protein_sequence_args import add_protein_sequence_args
 from isovar.cli.variant_sequences_args import add_variant_sequence_args
@@ -23,3 +26,20 @@ def test_extend_parser():
     eq_(args.maf, ["ZZZ.maf"])
     eq_(args.variant, [["chr1", "39000", "C", "G"]])
     eq_(args.bam, "xyz.bam")
+
+
+def test_use_soft_clipped_bases_default_off():
+    parser = make_rna_reads_arg_parser()
+    args = parser.parse_args(["--vcf", "x.vcf", "--bam", "x.bam"])
+    rc = read_collector_from_args(args)
+    eq_(rc.use_soft_clipped_bases, False)
+
+
+def test_use_soft_clipped_bases_flag_on():
+    parser = make_rna_reads_arg_parser()
+    args = parser.parse_args([
+        "--vcf", "x.vcf",
+        "--bam", "x.bam",
+        "--use-soft-clipped-bases"])
+    rc = read_collector_from_args(args)
+    eq_(rc.use_soft_clipped_bases, True)


### PR DESCRIPTION
## Summary
- Added `--use-soft-clipped-bases` to the CLI RNA argument group.
- Wired it through `read_collector_from_args`.
- Two tests: default off, flag turns it on.
- Bumped version to 1.4.9.

Fixes #134

## Test plan
- [x] `./test.sh` passes (158 tests)
- [x] `./lint.sh` passes