### PR TITLE
Fix docs: #128 #129 #133 #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ A variant which fails one or more filters is not excluded from the result collec
 If a result collection is flattened into a DataFrame then each filter is included as a column. 
 
 It's also possible to filter on boolean properties (without numerical thresholds) by passing `filter_flags` to `run_isovar`. These boolean
-properties can be further negated by prepending 'not_' to the property name, so that both `'protein_sequence_matches_predicted_effect'` and `'not_protein_sequence_matches_predicted_effect'` are valid names for `filter_flags`.
+properties can be further negated by prepending 'not_' to the property name, so that both `'protein_sequence_matches_predicted_mutation_effect'` and `'not_protein_sequence_matches_predicted_mutation_effect'` are valid names for `filter_flags`.
 
 ## Commandline 
 

--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.9"
+__version__ = "1.4.10"
 
 
 from .allele_read import AlleleRead

--- a/isovar/dataframe_builder.py
+++ b/isovar/dataframe_builder.py
@@ -49,8 +49,8 @@ class DataFrameBuilder(object):
             named '_fields' which is a list of field names.
 
         exclude : set
-            Field names from element_class which should be used as columns for
-            the DataFrame we're building
+            Field names from element_class which should be omitted from the
+            DataFrame we're building
 
         converters : dict
             Dictionary of names mapping to functions. These functions will be

--- a/isovar/locus_read.py
+++ b/isovar/locus_read.py
@@ -55,7 +55,7 @@ class LocusRead(ValueObject):
             cDNA sequence
 
         reference_positions : list of (int or None)
-            For every base in the sequence, which base-1 reference position
+            For every base in the sequence, which base-0 reference position
             does it map to, or None if the read base is an insertion or soft-clipped
 
         quality_scores : array of int

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -122,13 +122,15 @@ def run_isovar(
         they can also be negated by prepending "not_",
         such as "not_has_protein_sequence".
 
-    decompress_threads : int
+    decompression_threads : int
         Number of threads used by htslib to decompress BAM/CRAM
         files.
 
-    Generator of IsovarResult objects, one for each variant. The
-    `protein_sequences` field of the IsovarVar result will be empty
-    if no sequences could be determined.
+    Returns
+    -------
+    list of IsovarResult
+        One per variant. The `protein_sequences` field will be empty
+        if no sequences could be determined.
     """
     if filter_thresholds is None:
         filter_thresholds = OrderedDict(DEFAULT_FILTER_THRESHOLDS)


### PR DESCRIPTION
## Summary
Combined documentation fix PR:
- **#128**: `LocusRead.reference_positions` docstring corrected from base-1 to base-0.
- **#129**: `run_isovar` docstring fixed param name (`decompress_threads` → `decompression_threads`) and return type ("Generator" → "list of IsovarResult").
- **#133**: README example `protein_sequence_matches_predicted_effect` → `protein_sequence_matches_predicted_mutation_effect`.
- **#135**: `DataFrameBuilder.exclude` docstring corrected from "should be used" to "should be omitted".
- Bumped version to 1.4.10.

Fixes #128, #129, #133, #135

## Test plan
- [x] `./test.sh` passes (158 tests)
- [x] `./lint.sh` passes