### PR TITLE
[codex] Clamp widened fetch start at contig boundary

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,4 +51,5 @@ jobs:
         run: |
           ./test.sh
       - name: Publish coverage to Coveralls
+        if: matrix.python-version == '3.11'
         uses: coverallsapp/github-action@v2.2.3

--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.16"
+__version__ = "1.4.17"
 
 
 from .allele_read import AlleleRead

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -322,7 +322,7 @@ class ReadCollector(object):
         total_count = 0
         # check overlap against wider overlap to make sure we don't miss
         # any reads
-        base0_pos_before_start = base0_start_inclusive - 1
+        base0_pos_before_start = max(0, base0_start_inclusive - 1)
         base0_pos_after_end = base0_end_exclusive + 1
         for aligned_segment in alignment_file.fetch(
             chromosome, base0_pos_before_start, base0_pos_after_end

--- a/tests/test_locus_reads.py
+++ b/tests/test_locus_reads.py
@@ -239,6 +239,24 @@ def test_locus_reads_dataframe():
     eq_(len(df), n_reads_expected)
 
 
+def test_locus_reads_clamps_fetch_start_at_contig_boundary():
+    """
+    Querying a locus at the first aligned base of a contig should not widen the
+    fetch interval to a negative start coordinate.
+
+    Regression test for GitHub issue #161.
+    """
+    samfile = load_bam("data/primary.chr1.bam")
+    read_creator = ReadCollector()
+    reads = read_creator.get_locus_reads(
+        samfile,
+        "chr1",
+        base0_start_inclusive=0,
+        base0_end_exclusive=1,
+    )
+    assert isinstance(reads, list)
+
+
 def _make_mock_pysam_read_with_none_mapq():
     """
     Create a mock pysam read whose mapping_quality is None.


### PR DESCRIPTION
## Summary
- clamp the widened fetch start in `ReadCollector.get_locus_reads` so position-1 queries never pass a negative start to `pysam`
- add a regression test that exercises the contig-boundary path against a real BAM-backed `AlignmentFile`
- bump the package version to `1.4.17`

## Root Cause
`get_locus_reads` widens the query interval by one base on each side before calling `AlignmentFile.fetch(...)`. For a variant at the first aligned base of a contig, that produced `-1` as the fetch start and `pysam` raised `ValueError: start out of range (-1)`.

Closes #161.

## Validation
- `./lint.sh`
- `./test.sh`