### PR TITLE
[codex] Restore read-level CLI output

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.17"
+__version__ = "1.4.18"
 
 
 from .allele_read import AlleleRead

--- a/isovar/cli/isovar_allele_reads.py
+++ b/isovar/cli/isovar_allele_reads.py
@@ -19,7 +19,7 @@ import sys
 from ..logging import get_logger
 from .rna_args import (
     make_rna_reads_arg_parser,
-    read_evidence_dataframe_from_args
+    allele_reads_dataframe_from_args,
 )
 from .output_args import add_output_args, write_dataframe
 
@@ -35,6 +35,6 @@ def run(args=None):
         args = sys.argv[1:]
     args = parser.parse_args(args)
     logger.info(args)
-    df = read_evidence_dataframe_from_args(args)
+    df = allele_reads_dataframe_from_args(args)
     logger.info(df)
     write_dataframe(df, args)

--- a/isovar/cli/isovar_variant_reads.py
+++ b/isovar/cli/isovar_variant_reads.py
@@ -18,7 +18,7 @@ import sys
 
 from ..logging import get_logger
 from .rna_args import (
-    read_evidence_dataframe_from_args,
+    variant_reads_dataframe_from_args,
     make_rna_reads_arg_parser,
 )
 from .output_args import add_output_args, write_dataframe
@@ -38,6 +38,6 @@ def run(args=None):
         args = sys.argv[1:]
     args = parser.parse_args(args)
     logger.info(args)
-    df = read_evidence_dataframe_from_args(args)
+    df = variant_reads_dataframe_from_args(args)
     logger.info(df)
     write_dataframe(df, args)

--- a/isovar/cli/rna_args.py
+++ b/isovar/cli/rna_args.py
@@ -139,6 +139,19 @@ def variant_reads_generator_from_args(args):
         yield variant, read_evidence.alt_reads
 
 
+def allele_reads_generator_from_args(args):
+    """
+    Creates a generator of (Variant, list of AlleleRead) from parsed
+    arguments, including all reads at each variant locus.
+    """
+    for variant, read_evidence in read_evidence_generator_from_args(args):
+        yield variant, (
+            list(read_evidence.ref_reads)
+            + list(read_evidence.alt_reads)
+            + list(read_evidence.other_reads)
+        )
+
+
 def read_evidence_dataframe_from_args(args):
     """
     Collect ReadEvidence for each variant and turn them into a DataFrame
@@ -147,9 +160,25 @@ def read_evidence_dataframe_from_args(args):
         read_evidence_generator_from_args(args))
 
 
+def allele_reads_dataframe_from_args(args):
+    """
+    Collect all allele reads for each variant and turn them into a DataFrame.
+    """
+    return allele_reads_to_dataframe(
+        allele_reads_generator_from_args(args))
+
+
+def variant_reads_dataframe_from_args(args):
+    """
+    Collect alt-supporting reads for each variant and turn them into a
+    DataFrame.
+    """
+    return allele_reads_to_dataframe(
+        variant_reads_generator_from_args(args))
+
+
 def variants_reads_dataframe_from_args(args):
     """
     Collect variant reads for each variant and turn them into a DataFrame
     """
-    return allele_reads_to_dataframe(
-        read_evidence_generator_from_args(args))
+    return variant_reads_dataframe_from_args(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@
 import tempfile
 from os import remove
 from os.path import getsize, exists
+import pandas as pd
 
 from .testing_helpers import data_path
 
@@ -24,6 +25,10 @@ from isovar.cli.isovar_reference_contexts import run as isovar_reference_context
 from isovar.cli.isovar_variant_reads import run as isovar_variant_reads
 from isovar.cli.isovar_variant_sequences import run as isovar_variant_sequences
 from isovar.cli.isovar_main import run as isovar_main
+from isovar.cli.rna_args import (
+    make_rna_reads_arg_parser,
+    variants_reads_dataframe_from_args,
+)
 
 vcf_args = [
     "--vcf",
@@ -36,7 +41,7 @@ args_with_bam = vcf_args + [
 ]
 
 
-def run_cli_fn(fn, include_bam_in_args=True):
+def run_cli_fn(fn, include_bam_in_args=True, return_dataframe=False):
     with tempfile.NamedTemporaryFile(delete=False) as f:
         output_path = f.name
     assert not exists(output_path) == 0
@@ -47,7 +52,11 @@ def run_cli_fn(fn, include_bam_in_args=True):
         args = vcf_args + output_args
     fn(args)
     assert getsize(output_path) > 0
+    if return_dataframe:
+        df = pd.read_csv(output_path)
     remove(output_path)
+    if return_dataframe:
+        return df
 
 
 def test_cli_allele_counts():
@@ -55,7 +64,10 @@ def test_cli_allele_counts():
 
 
 def test_cli_allele_reads():
-    run_cli_fn(isovar_allele_reads)
+    df = run_cli_fn(isovar_allele_reads, return_dataframe=True)
+    assert set(["prefix", "allele", "suffix", "name", "sequence", "gene"]).issubset(df.columns)
+    assert "ref_reads" not in df.columns
+    assert len(df) == 293
 
 
 def test_cli_reference_contexts():
@@ -71,7 +83,10 @@ def test_cli_translations():
 
 
 def test_cli_variant_reads():
-    run_cli_fn(isovar_variant_reads)
+    df = run_cli_fn(isovar_variant_reads, return_dataframe=True)
+    assert set(["prefix", "allele", "suffix", "name", "sequence", "gene"]).issubset(df.columns)
+    assert "ref_reads" not in df.columns
+    assert len(df) == 42
 
 
 def test_cli_variant_sequences():
@@ -79,3 +94,10 @@ def test_cli_variant_sequences():
 
 def test_cli_main():
     run_cli_fn(isovar_main)
+
+
+def test_variant_reads_dataframe_helper():
+    args = make_rna_reads_arg_parser().parse_args(args_with_bam)
+    df = variants_reads_dataframe_from_args(args)
+    assert set(["prefix", "allele", "suffix", "name", "sequence", "gene"]).issubset(df.columns)
+    assert len(df) == 42


### PR DESCRIPTION
## Summary

- restore `isovar-allele-reads` to emit per-read rows instead of aggregated read-evidence rows
- restore `isovar-variant-reads` to emit alt-supporting per-read rows
- fix the shared CLI dataframe helper so variant-read dataframe construction no longer raises `TypeError`
- add regression coverage for both CLI commands and the helper path

## Root Cause

The read-level CLIs were both wired to `read_evidence_dataframe_from_args`, which produces one aggregated row per variant. That bypassed the per-read dataframe helpers entirely, so the commands returned the same schema as `isovar-allele-counts` despite their docs promising read sequences. The dormant variant-read helper was also passing `ReadEvidence` objects into `allele_reads_to_dataframe`, which breaks because that builder expects iterables of `AlleleRead`.

## Validation

- `./lint.sh`
- `./test.sh`

Closes #165.
