### PR TITLE
[codex] Speed up ReadCollector position lookups

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.19"
+__version__ = "1.4.20"
 
 
 from .allele_read import AlleleRead

--- a/isovar/read_collector.py
+++ b/isovar/read_collector.py
@@ -146,6 +146,12 @@ class ReadCollector(object):
             )
             return None
 
+        reference_position_to_read_position = {
+            ref_pos: read_pos
+            for read_pos, ref_pos in enumerate(base0_reference_positions)
+            if ref_pos is not None
+        }
+
         reference_interval_size = base0_end_exclusive - base0_start_inclusive
         if reference_interval_size < 0:
             raise ValueError("Unexpected interval start after interval end")
@@ -185,18 +191,16 @@ class ReadCollector(object):
             # going to allow the start/end to be None.
             reference_position_before_insertion = base0_start_inclusive - 1
             reference_position_after_insertion = base0_start_inclusive
-            if reference_position_before_insertion in base0_reference_positions:
-                read_base0_before_insertion = base0_reference_positions.index(
-                    reference_position_before_insertion
-                )
-            else:
+            read_base0_before_insertion = reference_position_to_read_position.get(
+                reference_position_before_insertion
+            )
+            if read_base0_before_insertion is None:
                 return None
 
-            if reference_position_after_insertion in base0_reference_positions:
-                read_base0_after_insertion = base0_reference_positions.index(
-                    reference_position_after_insertion
-                )
-            else:
+            read_base0_after_insertion = reference_position_to_read_position.get(
+                reference_position_after_insertion
+            )
+            if read_base0_after_insertion is None:
                 return None
 
             if read_base0_after_insertion - read_base0_before_insertion == 1:
@@ -227,31 +231,31 @@ class ReadCollector(object):
             # figure out which read indices correspond to base0_start_inclusive and
             # base0_end_exclusive but this would fail if base0_end_exclusive is
             # after the end the end of the read.
-            if base0_start_inclusive in base0_reference_positions:
-                read_base0_start_inclusive = base0_reference_positions.index(
+            if base0_start_inclusive in reference_position_to_read_position:
+                read_base0_start_inclusive = reference_position_to_read_position[
                     base0_start_inclusive
-                )
-            elif base0_start_inclusive - 1 in base0_reference_positions:
+                ]
+            elif base0_start_inclusive - 1 in reference_position_to_read_position:
                 # if first base of reference locus isn't mapped, try getting the base
                 # before it and then adding one to its corresponding base index
-                read_base0_position_before_locus = base0_reference_positions.index(
+                read_base0_position_before_locus = reference_position_to_read_position[
                     base0_start_inclusive - 1
-                )
+                ]
                 read_base0_start_inclusive = read_base0_position_before_locus + 1
             else:
                 return None
 
-            if base0_end_exclusive in base0_reference_positions:
-                read_base0_end_exclusive = base0_reference_positions.index(
+            if base0_end_exclusive in reference_position_to_read_position:
+                read_base0_end_exclusive = reference_position_to_read_position[
                     base0_end_exclusive
-                )
-            elif (base0_end_exclusive - 1) in base0_reference_positions:
+                ]
+            elif (base0_end_exclusive - 1) in reference_position_to_read_position:
                 # if exclusive last index of reference interval doesn't have a corresponding
                 # base position then try getting the base position of the reference
                 # position before it and then adding one
-                read_base0_end_inclusive = base0_reference_positions.index(
+                read_base0_end_inclusive = reference_position_to_read_position[
                     base0_end_exclusive - 1
-                )
+                ]
                 read_base0_end_exclusive = read_base0_end_inclusive + 1
             else:
                 return None

--- a/tests/test_locus_reads.py
+++ b/tests/test_locus_reads.py
@@ -22,6 +22,21 @@ from .mock_objects import MockAlignmentFile, make_pysam_read
 from .testing_helpers import assert_equal_fields, load_bam, data_path
 from .common import eq_
 
+
+class TrackingReferencePositions(list):
+    """
+    Count linear index scans over reference positions.
+    """
+
+    def __init__(self, values):
+        super().__init__(values)
+        self.index_calls = 0
+
+    def index(self, *args, **kwargs):
+        self.index_calls += 1
+        return super().index(*args, **kwargs)
+
+
 def test_locus_reads_snv():
     """
     test_partitioned_read_sequences_snv : Test that read gets correctly
@@ -255,6 +270,39 @@ def test_locus_reads_clamps_fetch_start_at_contig_boundary():
         base0_end_exclusive=1,
     )
     assert isinstance(reads, list)
+
+
+def test_locus_read_avoids_linear_index_scans_over_reference_positions():
+    """
+    Regression test for GitHub issue #163.
+
+    Converting the read/reference overlap interval should use a single
+    reference-position lookup table instead of repeated linear `list.index`
+    scans over the read's reference positions.
+    """
+    real_read = make_pysam_read(seq="ACCGTG", cigar="6M", mdtag="3G2")
+    tracking_positions = TrackingReferencePositions([0, 1, 2, 3, 4, 5])
+
+    mock_read = MagicMock()
+    mock_read.query_name = real_read.query_name
+    mock_read.query_sequence = real_read.query_sequence
+    mock_read.query_qualities = real_read.query_qualities
+    mock_read.query_alignment_start = real_read.query_alignment_start
+    mock_read.query_alignment_end = real_read.query_alignment_end
+    mock_read.is_secondary = False
+    mock_read.is_duplicate = False
+    mock_read.is_unmapped = False
+    mock_read.mapping_quality = real_read.mapping_quality
+    mock_read.get_reference_positions.return_value = tracking_positions
+
+    read_collector = ReadCollector()
+    result = read_collector.locus_read_from_pysam_aligned_segment(
+        mock_read,
+        base0_start_inclusive=3,
+        base0_end_exclusive=4,
+    )
+    assert result is not None
+    eq_(tracking_positions.index_calls, 0)
 
 
 def _make_mock_pysam_read_with_none_mapq():


### PR DESCRIPTION
## Summary

- replace repeated `list.index()` scans in `ReadCollector` with a single reference-position lookup table
- keep the read-interval logic unchanged for insertions, substitutions, and deletions
- add a regression test that fails if `locus_read_from_pysam_aligned_segment` goes back to linear index scans

## Root Cause

`ReadCollector.locus_read_from_pysam_aligned_segment` repeatedly checked membership in `base0_reference_positions` and then called `.index()` on the same list in the hot read-processing path. That did several linear passes over the same per-read position list for every locus conversion even though the mapping from reference position to read position is fixed for the whole read.

## Validation

- `./lint.sh`
- `./test.sh`

Closes #163.
