### PR TITLE
[codex] Fix run_isovar filter flag docs

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.20"
+__version__ = "1.4.21"
 
 
 from .allele_read import AlleleRead

--- a/isovar/main.py
+++ b/isovar/main.py
@@ -87,7 +87,7 @@ def run_isovar(
     into amino acid sequences. Collects both the read evidence and
     protein sequences into IsovarResult objects. The values of any filters
     which are supplied in the filter_thresholds argument are attached to
-    each IsovarResult's filter_values_dict field.
+    each IsovarResult's filter_values field.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def run_isovar(
     filter_flags : list of str
         List of boolean fields of IsovarResult used for filtering,
         they can also be negated by prepending "not_",
-        such as "not_has_protein_sequence".
+        such as "not_has_mutant_protein_sequence_from_rna".
 
     decompression_threads : int
         Number of threads used by htslib to decompress BAM/CRAM

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ from isovar import run_isovar, isovar_results_to_dataframe
 from .common import eq_
 from .testing_helpers import data_path
 
+
 def test_isovar_main_to_dataframe():
     results = run_isovar(
         variants=data_path("data/b16.f10/b16.vcf"),
@@ -25,3 +26,11 @@ def test_isovar_main_to_dataframe():
     # to translate protein sequences
     eq_(df["passes_all_filters"].sum(), 2)
 
+
+def test_run_isovar_docstring_uses_current_filter_api_names():
+    doc = run_isovar.__doc__
+    assert doc is not None
+    assert "filter_values field" in doc
+    assert "filter_values_dict" not in doc
+    assert '"not_has_mutant_protein_sequence_from_rna"' in doc
+    assert '"not_has_protein_sequence"' not in doc


### PR DESCRIPTION
## Summary

- fix `run_isovar`'s docstring to reference the real `IsovarResult.filter_values` field
- replace the stale `not_has_protein_sequence` example with the actual `has_mutant_protein_sequence_from_rna` flag name
- add a regression test that keeps the docstring aligned with the current filter API names

## Root Cause

The `run_isovar` docstring had drifted behind the implementation. It still referenced an old `filter_values_dict` name and used a negated filter-flag example that no longer exists on `IsovarResult`, which could mislead anyone relying on inline help or IDE documentation instead of the README.

## Validation

- `./lint.sh`
- `./test.sh`

Closes #162.
