### PR TITLE
[codex] Add varcode assembly provider adapter

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.4.24"
+__version__ = "1.5.0"
 
 
 from .allele_read import AlleleRead
@@ -25,6 +25,7 @@ from .read_evidence import ReadEvidence
 from .variant_orf import VariantORF
 from .variant_sequence import VariantSequence
 from .variant_sequence_creator import VariantSequenceCreator
+from .varcode_adapter import VarcodeAdapter
 
 
 __all__ = [
@@ -40,4 +41,5 @@ __all__ = [
     "VariantORF",
     "VariantSequence",
     "VariantSequenceCreator",
+    "VarcodeAdapter",
 ]

--- a/isovar/varcode_adapter.py
+++ b/isovar/varcode_adapter.py
@@ -1,0 +1,145 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Adapter from IsovarResult collections to varcode's IsovarAssemblyProvider.
+
+This is intentionally conservative: it exposes transcript-keyed assembled
+contigs from existing Translation objects and surfaces already-known phased RNA
+variants on those contigs. It does not yet discover germline SNPs or unexplained
+contig edits directly from the assembled cDNA sequence.
+"""
+
+from collections import namedtuple
+
+from .dna import reverse_complement_dna
+from .variant_helpers import interbase_range_affected_by_variant_on_transcript
+
+
+TrimmedVariant = namedtuple(
+    "TrimmedVariant",
+    ["start", "ref", "alt", "is_insertion"])
+
+
+class VarcodeAdapter(object):
+    """
+    Present IsovarResult objects through varcode's IsovarAssemblyProvider
+    protocol without changing run_isovar's existing return type.
+    """
+
+    def __init__(self, isovar_results):
+        self._entries_by_variant_and_transcript = {}
+        for result in isovar_results:
+            for protein_sequence in result.sorted_protein_sequences:
+                for translation in protein_sequence.translations:
+                    for transcript in translation.reference_context.transcripts:
+                        key = (result.variant, self._transcript_key(transcript))
+                        if key not in self._entries_by_variant_and_transcript:
+                            self._entries_by_variant_and_transcript[key] = (
+                                result,
+                                translation,
+                                transcript,
+                            )
+
+    @staticmethod
+    def _transcript_key(transcript):
+        return getattr(transcript, "id", transcript)
+
+    @staticmethod
+    def _variant_sort_key(variant):
+        return (
+            variant.contig,
+            variant.start,
+            variant.ref,
+            variant.alt,
+        )
+
+    def _entry(self, variant, transcript):
+        if transcript is None:
+            return None
+        return self._entries_by_variant_and_transcript.get((
+            variant,
+            self._transcript_key(transcript),
+        ))
+
+    @staticmethod
+    def _trimmed_variant_from_result(result):
+        ref = result.read_evidence.trimmed_ref
+        alt = result.read_evidence.trimmed_alt
+        return TrimmedVariant(
+            start=result.read_evidence.trimmed_base1_start,
+            ref=ref,
+            alt=alt,
+            is_insertion=len(ref) == 0 and len(alt) > 0)
+
+    def _transcript_edit(self, result, transcript):
+        from varcode.mutant_transcript import TranscriptEdit
+
+        trimmed_variant = self._trimmed_variant_from_result(result)
+        try:
+            cdna_start, cdna_end = interbase_range_affected_by_variant_on_transcript(
+                trimmed_variant,
+                transcript)
+        except ValueError:
+            return None
+
+        alt_bases = trimmed_variant.alt
+        if getattr(transcript, "strand", None) == "-":
+            alt_bases = reverse_complement_dna(alt_bases)
+
+        return TranscriptEdit(
+            cdna_start=cdna_start,
+            cdna_end=cdna_end,
+            alt_bases=alt_bases,
+            source_variant=result.variant)
+
+    def has_contig(self, variant, transcript):
+        return self._entry(variant, transcript) is not None
+
+    def variants_in_contig(self, variant, transcript):
+        entry = self._entry(variant, transcript)
+        if entry is None:
+            return ()
+
+        result, _, _ = entry
+        variants = [
+            phased_variant
+            for phased_variant in result.phased_variants_in_protein_sequence
+            if self.has_contig(phased_variant, transcript)
+        ]
+        return tuple(sorted(variants, key=self._variant_sort_key))
+
+    def mutant_transcript(self, variant, transcript):
+        entry = self._entry(variant, transcript)
+        if entry is None:
+            return None
+
+        from varcode.mutant_transcript import MutantTranscript
+
+        result, translation, matched_transcript = entry
+        transcript_edit = self._transcript_edit(result, matched_transcript)
+        evidence = {
+            "num_supporting_reads": len(translation.reads),
+            "num_supporting_fragments": len({read.name for read in translation.reads}),
+            "num_cdna_mismatches_before_variant": (
+                translation.num_mismatches_before_variant),
+            "num_cdna_mismatches_after_variant": (
+                translation.num_mismatches_after_variant),
+        }
+        edits = (transcript_edit,) if transcript_edit is not None else ()
+        return MutantTranscript(
+            reference_transcript=matched_transcript,
+            edits=edits,
+            cdna_sequence=translation.cdna_sequence,
+            mutant_protein_sequence=translation.amino_acids,
+            annotator_name="isovar",
+            evidence=evidence)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyensembl>=1.5.0
-varcode>=0.9.0
+varcode>=4.15.0
 pandas>=0.23.0
 pysam>=0.15.2
 psutil

--- a/tests/test_varcode_adapter.py
+++ b/tests/test_varcode_adapter.py
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import pytest
+
+from varcode.phasing import (
+    IsovarAssemblyProvider,
+    IsovarPhaseResolver,
+    apply_phase_resolver_to_effects,
+)
+
+from isovar import VarcodeAdapter, run_isovar
+
+from .common import eq_
+from .testing_helpers import data_path
+
+
+@pytest.fixture(scope="module")
+def result_and_transcript():
+    results = run_isovar(
+        variants=data_path("data/b16.f10/b16.vcf"),
+        alignment_file=data_path("data/b16.f10/b16.combined.sorted.bam"))
+    result = next(
+        isovar_result
+        for isovar_result in results
+        if isovar_result.has_mutant_protein_sequence_from_rna
+    )
+    transcript = result.top_protein_sequence.transcripts[0]
+    return results, result, transcript
+
+
+def test_varcode_adapter_satisfies_runtime_protocol(result_and_transcript):
+    results, _, _ = result_and_transcript
+    provider = VarcodeAdapter(results)
+    assert isinstance(provider, IsovarAssemblyProvider)
+
+
+def test_varcode_adapter_exposes_contig_and_mutant_transcript(result_and_transcript):
+    results, result, transcript = result_and_transcript
+    provider = VarcodeAdapter(results)
+
+    assert provider.has_contig(result.variant, transcript)
+
+    mutant_transcript = provider.mutant_transcript(result.variant, transcript)
+    assert mutant_transcript is not None
+    eq_(mutant_transcript.reference_transcript.id, transcript.id)
+    assert mutant_transcript.cdna_sequence in result.top_protein_sequence.cdna_sequences
+    eq_(mutant_transcript.mutant_protein_sequence, result.top_protein_sequence.amino_acids)
+    eq_(mutant_transcript.annotator_name, "isovar")
+    eq_(len(mutant_transcript.edits), 1)
+    eq_(mutant_transcript.edits[0].source_variant, result.variant)
+
+
+def test_isovar_phase_resolver_applies_contig_mutant_transcript(result_and_transcript):
+    results, result, transcript = result_and_transcript
+    provider = VarcodeAdapter(results)
+    resolver = IsovarPhaseResolver(provider)
+
+    @dataclass
+    class DummyEffect(object):
+        variant: object
+        transcript: object
+        mutant_transcript: object = None
+
+    effect = DummyEffect(variant=result.variant, transcript=transcript)
+    effects = [effect]
+
+    resolved_effects = apply_phase_resolver_to_effects(effects, resolver)
+    eq_(resolved_effects, effects)
+    assert effect.mutant_transcript is not None
+    eq_(effect.mutant_transcript.reference_transcript.id, transcript.id)
+    eq_(resolver.phased_partners(result.variant, transcript), provider.variants_in_contig(result.variant, transcript))


### PR DESCRIPTION
## Summary
- add `isovar.varcode_adapter.VarcodeAdapter`, a dedicated adapter that presents existing `IsovarResult` collections through varcode's `IsovarAssemblyProvider` protocol
- project transcript-keyed `Translation` objects into varcode `MutantTranscript` values so `IsovarPhaseResolver` can attach contig-derived proteins to effects
- bump the varcode dependency floor to `>=4.15.0` and add integration tests against the real `varcode.phasing` runtime protocol

## Notes
- `variants_in_contig()` currently exposes already-known phased RNA variants for the transcript-specific contig; it does not yet enumerate germline SNPs or unexplained contig edits directly from assembled cDNA
- downstream coordination is tracked in openvax/vaxrank#238 because current vaxrank still pins `varcode<3`

## Validation
- ./lint.sh
- ./test.sh

Closes #160
