### PR TITLE
Add IsovarReadPhasing adapter for RNA-read variant phasing

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -23,6 +23,7 @@ from .protein_sequence import ProteinSequence
 from .protein_sequence_creator import ProteinSequenceCreator
 from .read_collector import ReadCollector
 from .read_evidence import ReadEvidence
+from .read_phasing import IsovarReadPhasing
 from .transcript_assembly_edit import TranscriptAssemblyEdit
 from .variant_orf import VariantORF
 from .variant_sequence import VariantSequence
@@ -35,6 +36,7 @@ __all__ = [
     "isovar_results_to_dataframe",
     "AlleleRead",
     "PhaseGroup",
+    "IsovarReadPhasing",
     "IsovarResult",
     "LocusRead",
     "ProteinSequence",

--- a/isovar/read_phasing.py
+++ b/isovar/read_phasing.py
@@ -42,6 +42,16 @@ both directions with the same minimum, so
 ``v2 in phasing.partners_in_cis(v1)`` implies
 ``v1 in phasing.partners_in_cis(v2)`` whenever both variants are in the
 input set.
+
+``partners_in_cis`` and ``has_evidence`` answer independent questions and
+are not cross-checked: ``partners_in_cis`` returns
+``phased_variants_in_supporting_reads`` as-is from the input results, so
+a caller constructing inputs by hand could observe ``has_evidence(v)``
+return ``False`` while ``partners_in_cis(v)`` returns a non-empty tuple.
+Outputs from ``run_isovar``/``annotate_phased_variants`` never exhibit
+this -- the upstream pipeline only populates partners for variants that
+have shared supporting reads, which implies positive alt-fragment counts
+on both sides.
 """
 
 

--- a/isovar/read_phasing.py
+++ b/isovar/read_phasing.py
@@ -80,8 +80,7 @@ class IsovarReadPhasing(object):
         ----------
         isovar_results : Iterable[IsovarResult]
             Results from a finished Isovar run (e.g. the output of
-            ``run_isovar``). The iterable is consumed once. If the
-            same variant appears more than once, the last entry wins.
+            ``run_isovar``). The iterable is consumed once.
         """
         self._by_variant = {
             result.variant: result

--- a/isovar/read_phasing.py
+++ b/isovar/read_phasing.py
@@ -14,14 +14,15 @@
 Adapter that exposes Isovar's per-variant RNA-read co-occurrence as a
 narrow read-phasing interface.
 
-Satisfies varcode's ``ReadPhasingSource`` Protocol
-(``has_evidence(variant)`` + ``partners_in_cis(variant)``; see
-openvax/varcode#378 and openvax/varcode#379) and plugs directly into
-``varcode.ReadPhaseResolver``. The companion ``MutantTranscriptSource``
-concern (assembled-cDNA-derived mutant transcripts) is intentionally
-not covered here -- it's a separate axis, served by
-:class:`isovar.VarcodeAdapter` today and slated for a focused
-``IsovarMutantTranscript`` class per openvax/isovar#184.
+Implements the ``has_evidence(variant)`` + ``partners_in_cis(variant)``
+shape that varcode's ``ReadPhasingSource`` Protocol adopts in
+openvax/varcode#378 / openvax/varcode#379; once those land, an instance
+of this class plugs directly into ``varcode.ReadPhaseResolver``. The
+companion ``MutantTranscriptSource`` concern (assembled-cDNA-derived
+mutant transcripts) is intentionally not covered here -- it's a
+separate axis, served by :class:`isovar.VarcodeAdapter` today and
+slated for a focused ``IsovarMutantTranscript`` class per
+openvax/isovar#184.
 
 Answers only the phasing question: "are these two variants observed on
 the same RNA reads?" -- derived from

--- a/isovar/read_phasing.py
+++ b/isovar/read_phasing.py
@@ -18,28 +18,60 @@ Distinct from :class:`isovar.VarcodeAdapter`, which implements varcode's
 full ``IsovarAssemblyProvider`` protocol (assembled contigs +
 reference-keyed mutant transcripts). This adapter answers only the
 phasing question: "are these two variants observed on the same RNA
-reads?" — derived from
+reads?" -- derived from
 :attr:`isovar.IsovarResult.phased_variants_in_supporting_reads`.
+
+Contract
+--------
+``IsovarReadPhasing`` reads exactly three attributes from each element
+of its input iterable:
+
+* ``variant`` -- a hashable identity used as the index key.
+* ``num_alt_fragments`` -- int; non-zero means
+  :meth:`IsovarReadPhasing.has_evidence` returns ``True``.
+* ``phased_variants_in_supporting_reads`` -- iterable of variants
+  co-observed on supporting RNA reads.
+
+Any object exposing those three attributes is a valid input; the
+adapter is intentionally duck-typed so tests, mocks, and alternative
+RNA-phasing producers (e.g. long-read tools) can target the same shape.
+
+Co-occurrence symmetry is inherited from the underlying field: Isovar's
+``compute_phasing_counts`` builds counts symmetrically and thresholds
+both directions with the same minimum, so
+``v2 in phasing.partners_in_cis(v1)`` implies
+``v1 in phasing.partners_in_cis(v2)`` whenever both variants are in the
+input set.
 """
 
 
 class IsovarReadPhasing(object):
     """
-    Indexes a collection of IsovarResult objects by variant and answers
-    read-phasing queries via Isovar's per-variant
+    Index a collection of IsovarResult-shaped objects by variant and
+    answer RNA-read phasing queries from
     ``phased_variants_in_supporting_reads``.
 
-    Example
-    -------
-    >>> from isovar import run_isovar, IsovarReadPhasing
-    >>> results = run_isovar(
-    ...     variants="tumor.vcf",
-    ...     alignment_file="tumor.rna.bam")
+    Examples
+    --------
+    >>> from types import SimpleNamespace
+    >>> from varcode import Variant
+    >>> v1 = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    >>> v2 = Variant("1", 11, "G", "T", normalize_contig_names=False)
+    >>> results = [
+    ...     SimpleNamespace(
+    ...         variant=v1,
+    ...         num_alt_fragments=3,
+    ...         phased_variants_in_supporting_reads={v2}),
+    ...     SimpleNamespace(
+    ...         variant=v2,
+    ...         num_alt_fragments=2,
+    ...         phased_variants_in_supporting_reads={v1}),
+    ... ]
     >>> phasing = IsovarReadPhasing(results)
-    >>> phasing.has_evidence(some_variant)
+    >>> phasing.has_evidence(v1)
     True
-    >>> phasing.partners_in_cis(some_variant)
-    (Variant(...), ...)
+    >>> phasing.partners_in_cis(v1) == (v2,)
+    True
     """
 
     def __init__(self, isovar_results):
@@ -48,20 +80,24 @@ class IsovarReadPhasing(object):
         ----------
         isovar_results : Iterable[IsovarResult]
             Results from a finished Isovar run (e.g. the output of
-            ``run_isovar``). The iterable is consumed once.
+            ``run_isovar``). The iterable is consumed once. If the
+            same variant appears more than once, the last entry wins.
         """
         self._by_variant = {
             result.variant: result
             for result in isovar_results
         }
 
+    def __repr__(self):
+        return "IsovarReadPhasing(%d variants)" % len(self._by_variant)
+
     def has_evidence(self, variant):
         """
         True iff Isovar saw at least one alt-supporting RNA fragment
         for ``variant``.
 
-        Returns False both when the variant was not in the input set
-        and when it was present but had no alt fragments.
+        Returns ``False`` both when the variant was not in the input
+        set and when it was present but had no alt fragments.
         """
         result = self._by_variant.get(variant)
         return result is not None and result.num_alt_fragments > 0
@@ -78,8 +114,9 @@ class IsovarReadPhasing(object):
         result = self._by_variant.get(variant)
         if result is None:
             return ()
-        partners = result.phased_variants_in_supporting_reads
-        return tuple(sorted(partners, key=_variant_sort_key))
+        return tuple(sorted(
+            result.phased_variants_in_supporting_reads,
+            key=_variant_sort_key))
 
 
 def _variant_sort_key(variant):

--- a/isovar/read_phasing.py
+++ b/isovar/read_phasing.py
@@ -1,0 +1,86 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Adapter that exposes Isovar's per-variant RNA-read co-occurrence as a
+narrow read-phasing interface.
+
+Distinct from :class:`isovar.VarcodeAdapter`, which implements varcode's
+full ``IsovarAssemblyProvider`` protocol (assembled contigs +
+reference-keyed mutant transcripts). This adapter answers only the
+phasing question: "are these two variants observed on the same RNA
+reads?" — derived from
+:attr:`isovar.IsovarResult.phased_variants_in_supporting_reads`.
+"""
+
+
+class IsovarReadPhasing(object):
+    """
+    Indexes a collection of IsovarResult objects by variant and answers
+    read-phasing queries via Isovar's per-variant
+    ``phased_variants_in_supporting_reads``.
+
+    Example
+    -------
+    >>> from isovar import run_isovar, IsovarReadPhasing
+    >>> results = run_isovar(
+    ...     variants="tumor.vcf",
+    ...     alignment_file="tumor.rna.bam")
+    >>> phasing = IsovarReadPhasing(results)
+    >>> phasing.has_evidence(some_variant)
+    True
+    >>> phasing.partners_in_cis(some_variant)
+    (Variant(...), ...)
+    """
+
+    def __init__(self, isovar_results):
+        """
+        Parameters
+        ----------
+        isovar_results : Iterable[IsovarResult]
+            Results from a finished Isovar run (e.g. the output of
+            ``run_isovar``). The iterable is consumed once.
+        """
+        self._by_variant = {
+            result.variant: result
+            for result in isovar_results
+        }
+
+    def has_evidence(self, variant):
+        """
+        True iff Isovar saw at least one alt-supporting RNA fragment
+        for ``variant``.
+
+        Returns False both when the variant was not in the input set
+        and when it was present but had no alt fragments.
+        """
+        result = self._by_variant.get(variant)
+        return result is not None and result.num_alt_fragments > 0
+
+    def partners_in_cis(self, variant):
+        """
+        Variants co-observed on supporting RNA reads with ``variant``.
+
+        Returns an empty tuple when ``variant`` is unknown or has no
+        co-observed partners. Partners are returned in a deterministic
+        order (by chromosome, start, ref, alt) so callers can rely on
+        ordering for snapshot tests.
+        """
+        result = self._by_variant.get(variant)
+        if result is None:
+            return ()
+        partners = result.phased_variants_in_supporting_reads
+        return tuple(sorted(partners, key=_variant_sort_key))
+
+
+def _variant_sort_key(variant):
+    return (variant.contig, variant.start, variant.ref, variant.alt)

--- a/isovar/read_phasing.py
+++ b/isovar/read_phasing.py
@@ -14,11 +14,17 @@
 Adapter that exposes Isovar's per-variant RNA-read co-occurrence as a
 narrow read-phasing interface.
 
-Distinct from :class:`isovar.VarcodeAdapter`, which implements varcode's
-full ``IsovarAssemblyProvider`` protocol (assembled contigs +
-reference-keyed mutant transcripts). This adapter answers only the
-phasing question: "are these two variants observed on the same RNA
-reads?" -- derived from
+Satisfies varcode's ``ReadPhasingSource`` Protocol
+(``has_evidence(variant)`` + ``partners_in_cis(variant)``; see
+openvax/varcode#378 and openvax/varcode#379) and plugs directly into
+``varcode.ReadPhaseResolver``. The companion ``MutantTranscriptSource``
+concern (assembled-cDNA-derived mutant transcripts) is intentionally
+not covered here -- it's a separate axis, served by
+:class:`isovar.VarcodeAdapter` today and slated for a focused
+``IsovarMutantTranscript`` class per openvax/isovar#184.
+
+Answers only the phasing question: "are these two variants observed on
+the same RNA reads?" -- derived from
 :attr:`isovar.IsovarResult.phased_variants_in_supporting_reads`.
 
 Contract

--- a/tests/test_read_phasing.py
+++ b/tests/test_read_phasing.py
@@ -1,0 +1,99 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from varcode import Variant
+
+from isovar import IsovarReadPhasing
+from isovar.allele_read import AlleleRead
+from isovar.isovar_result import IsovarResult
+from isovar.read_evidence import ReadEvidence
+
+from .common import eq_
+
+
+def _make_result(variant, alt_read_names, phased_partners=()):
+    read_evidence = ReadEvidence(
+        trimmed_base1_start=variant.start,
+        trimmed_ref=variant.ref,
+        trimmed_alt=variant.alt,
+        ref_reads=[],
+        alt_reads=[
+            AlleleRead(prefix="A", allele=variant.alt, suffix="T", name=name)
+            for name in alt_read_names
+        ],
+        other_reads=[],
+    )
+    return IsovarResult(
+        variant=variant,
+        read_evidence=read_evidence,
+        predicted_effect=None,
+        phased_variants_in_supporting_reads=set(phased_partners),
+    )
+
+
+def test_has_evidence_true_for_variant_with_alt_reads():
+    v = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([_make_result(v, alt_read_names={"r1", "r2"})])
+    assert phasing.has_evidence(v)
+
+
+def test_has_evidence_false_when_no_alt_reads():
+    v = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([_make_result(v, alt_read_names=set())])
+    assert not phasing.has_evidence(v)
+
+
+def test_has_evidence_false_for_unknown_variant():
+    v = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    unknown = Variant("1", 99, "G", "T", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([_make_result(v, alt_read_names={"r1"})])
+    assert not phasing.has_evidence(unknown)
+
+
+def test_partners_in_cis_returns_phased_variants():
+    v1 = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    v2 = Variant("1", 11, "G", "T", normalize_contig_names=False)
+    v3 = Variant("1", 12, "T", "G", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([
+        _make_result(v1, alt_read_names={"r1"}, phased_partners={v2, v3}),
+        _make_result(v2, alt_read_names={"r1"}, phased_partners={v1}),
+        _make_result(v3, alt_read_names={"r1"}, phased_partners={v1}),
+    ])
+    eq_(phasing.partners_in_cis(v1), (v2, v3))
+    eq_(phasing.partners_in_cis(v2), (v1,))
+
+
+def test_partners_in_cis_empty_when_no_partners():
+    v = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([_make_result(v, alt_read_names={"r1"})])
+    eq_(phasing.partners_in_cis(v), ())
+
+
+def test_partners_in_cis_empty_for_unknown_variant():
+    v = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    unknown = Variant("2", 50, "A", "G", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([_make_result(v, alt_read_names={"r1"})])
+    eq_(phasing.partners_in_cis(unknown), ())
+
+
+def test_partners_in_cis_is_deterministically_ordered():
+    anchor = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    later = Variant("1", 20, "A", "C", normalize_contig_names=False)
+    earlier = Variant("1", 5, "A", "C", normalize_contig_names=False)
+    other_chrom = Variant("2", 1, "A", "C", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([
+        _make_result(
+            anchor,
+            alt_read_names={"r1"},
+            phased_partners={later, earlier, other_chrom}),
+    ])
+    eq_(phasing.partners_in_cis(anchor), (earlier, later, other_chrom))

--- a/tests/test_read_phasing.py
+++ b/tests/test_read_phasing.py
@@ -20,9 +20,12 @@ from isovar import IsovarReadPhasing, run_isovar
 from isovar.allele_read import AlleleRead
 from isovar.isovar_result import IsovarResult
 from isovar.phasing import annotate_phased_variants
+from isovar.read_collector import ReadCollector
 from isovar.read_evidence import ReadEvidence
 
 from .common import eq_
+from .genomes_for_testing import grcm38
+from .mock_objects import MockAlignmentFile, make_pysam_read
 from .testing_helpers import data_path
 
 
@@ -245,3 +248,106 @@ def test_adapter_respects_min_shared_fragments_threshold():
     # Threshold filters out the single shared read, so no partners.
     eq_(phasing.partners_in_cis(v1), ())
     eq_(phasing.partners_in_cis(v2), ())
+
+
+# ---- synthetic somatic + germline phasing scenario -----------------------
+#
+# Builds a synthetic mini-BAM in-memory and walks the full
+# ReadCollector -> annotate_phased_variants -> IsovarReadPhasing
+# stack. The scenario mirrors the canonical motivating use case for
+# openvax/isovar#182 / openvax/varcode#268: a somatic SNV whose codon
+# overlaps a germline SNP, where reading direction alone can't tell
+# whether the two variants are in cis or trans -- only RNA-read
+# co-occurrence can.
+#
+# Imagined locus (mouse, b16-adjacent): chr1:1-10 reference is
+# `ACCTTGATCG`. A somatic SNV sits at chr1:4 (T>G), and an imagined
+# germline SNP sits at chr1:8 (T>A). The reads below are the kind of
+# RNA fragments Isovar's read collector would harvest from a tumor
+# BAM at this locus.
+#
+#   ref       :  A C C T T G A T C G
+#   pos (1-based) 1 2 3 4 5 6 7 8 9 10
+#   somatic@4 :        ^                      T>G
+#   germline@8:                    ^          T>A
+#
+# Three reads carry both alts (cis evidence), two carry only the
+# somatic alt, two carry only the germline alt. After phasing with
+# the default min_shared_fragments threshold of 2, the somatic and
+# germline calls should be reported as partners.
+
+
+def test_synthetic_somatic_and_germline_phased_on_rna_reads():
+    chromosome = "1"
+    somatic = Variant(
+        chromosome, 4, "T", "G", grcm38, normalize_contig_names=False)
+    germline = Variant(
+        chromosome, 8, "T", "A", grcm38, normalize_contig_names=False)
+
+    # Reads cover positions 1-10 (reference_start=0, 10M cigar). The
+    # MD tag encodes mismatches relative to the assumed reference
+    # `ACCTTGATCG`:
+    #   * both alts:    ACCGTGAACG -> mismatches at 0-based 3 and 7 -> MD=3T3T2
+    #   * somatic only: ACCGTGATCG -> mismatch at 0-based 3        -> MD=3T6
+    #   * germline only: ACCTTGAACG -> mismatch at 0-based 7        -> MD=7T2
+    def both_alts(name):
+        return make_pysam_read(
+            seq="ACCGTGAACG", cigar="10M", mdtag="3T3T2",
+            name=name, reference_start=0)
+
+    def somatic_only(name):
+        return make_pysam_read(
+            seq="ACCGTGATCG", cigar="10M", mdtag="3T6",
+            name=name, reference_start=0)
+
+    def germline_only(name):
+        return make_pysam_read(
+            seq="ACCTTGAACG", cigar="10M", mdtag="7T2",
+            name=name, reference_start=0)
+
+    reads = [
+        both_alts("frag-both-1"),
+        both_alts("frag-both-2"),
+        both_alts("frag-both-3"),
+        somatic_only("frag-somatic-1"),
+        somatic_only("frag-somatic-2"),
+        germline_only("frag-germline-1"),
+        germline_only("frag-germline-2"),
+    ]
+    samfile = MockAlignmentFile(references=(chromosome,), reads=reads)
+    collector = ReadCollector()
+
+    somatic_evidence = collector.read_evidence_for_variant(
+        variant=somatic, alignment_file=samfile)
+    germline_evidence = collector.read_evidence_for_variant(
+        variant=germline, alignment_file=samfile)
+
+    # Sanity-check the synthetic-data construction itself before
+    # exercising the adapter -- if the read collector doesn't pick
+    # the alts up as expected, downstream assertions would be
+    # misleading.
+    eq_(
+        somatic_evidence.alt_read_names,
+        {"frag-both-1", "frag-both-2", "frag-both-3",
+         "frag-somatic-1", "frag-somatic-2"})
+    eq_(
+        germline_evidence.alt_read_names,
+        {"frag-both-1", "frag-both-2", "frag-both-3",
+         "frag-germline-1", "frag-germline-2"})
+
+    annotated = annotate_phased_variants([
+        IsovarResult(
+            variant=somatic,
+            read_evidence=somatic_evidence,
+            predicted_effect=None),
+        IsovarResult(
+            variant=germline,
+            read_evidence=germline_evidence,
+            predicted_effect=None),
+    ])
+    phasing = IsovarReadPhasing(annotated)
+
+    assert phasing.has_evidence(somatic)
+    assert phasing.has_evidence(germline)
+    eq_(phasing.partners_in_cis(somatic), (germline,))
+    eq_(phasing.partners_in_cis(germline), (somatic,))

--- a/tests/test_read_phasing.py
+++ b/tests/test_read_phasing.py
@@ -12,15 +12,17 @@
 
 import doctest
 
+import pytest
 from varcode import Variant
 
 import isovar.read_phasing
-from isovar import IsovarReadPhasing
+from isovar import IsovarReadPhasing, run_isovar
 from isovar.allele_read import AlleleRead
 from isovar.isovar_result import IsovarResult
 from isovar.read_evidence import ReadEvidence
 
 from .common import eq_
+from .testing_helpers import data_path
 
 
 def _make_result(variant, alt_read_names, phased_partners=()):
@@ -118,3 +120,59 @@ def test_partners_in_cis_is_deterministically_ordered():
             phased_partners={later, earlier, other_chrom}),
     ])
     eq_(phasing.partners_in_cis(anchor), (earlier, later, other_chrom))
+
+
+# ---- end-to-end test against the b16 RNA fixture -------------------------
+#
+# Runs the full Isovar pipeline on the same b16 BAM/VCF used by
+# tests/test_varcode_adapter.py. The b16 fixture is small (a handful of
+# variants), so partner sets may be empty -- the structural assertions
+# below pass either way and would still catch a regression where the
+# adapter drops, fabricates, or misroutes phasing data.
+
+
+@pytest.fixture(scope="module")
+def b16_results():
+    return run_isovar(
+        variants=data_path("data/b16.f10/b16.vcf"),
+        alignment_file=data_path("data/b16.f10/b16.combined.sorted.bam"))
+
+
+def test_b16_has_evidence_matches_alt_fragment_count(b16_results):
+    phasing = IsovarReadPhasing(b16_results)
+    # `has_evidence` is defined as `num_alt_fragments > 0`; verify it
+    # against the real IsovarResult.num_alt_fragments rather than the
+    # adapter's internal state.
+    for result in b16_results:
+        eq_(
+            phasing.has_evidence(result.variant),
+            result.num_alt_fragments > 0)
+
+
+def test_b16_partners_are_subset_of_input_variants(b16_results):
+    phasing = IsovarReadPhasing(b16_results)
+    input_variants = {result.variant for result in b16_results}
+    for result in b16_results:
+        for partner in phasing.partners_in_cis(result.variant):
+            assert partner in input_variants, (
+                "partner %s not present in the input result set" % (partner,))
+
+
+def test_b16_partners_match_phased_variants_field(b16_results):
+    phasing = IsovarReadPhasing(b16_results)
+    for result in b16_results:
+        eq_(
+            set(phasing.partners_in_cis(result.variant)),
+            set(result.phased_variants_in_supporting_reads))
+
+
+def test_b16_phasing_is_symmetric(b16_results):
+    # Symmetry is the contract we promise in the module docstring; this
+    # is the integration-level check that it holds end-to-end against
+    # real data.
+    phasing = IsovarReadPhasing(b16_results)
+    for result in b16_results:
+        for partner in phasing.partners_in_cis(result.variant):
+            assert result.variant in phasing.partners_in_cis(partner), (
+                "asymmetric phasing: %s -> %s but not back" % (
+                    result.variant, partner))

--- a/tests/test_read_phasing.py
+++ b/tests/test_read_phasing.py
@@ -10,8 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import doctest
+
 from varcode import Variant
 
+import isovar.read_phasing
 from isovar import IsovarReadPhasing
 from isovar.allele_read import AlleleRead
 from isovar.isovar_result import IsovarResult
@@ -83,6 +86,24 @@ def test_partners_in_cis_empty_for_unknown_variant():
     unknown = Variant("2", 50, "A", "G", normalize_contig_names=False)
     phasing = IsovarReadPhasing([_make_result(v, alt_read_names={"r1"})])
     eq_(phasing.partners_in_cis(unknown), ())
+
+
+def test_repr_includes_variant_count():
+    v1 = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    v2 = Variant("1", 11, "G", "T", normalize_contig_names=False)
+    phasing = IsovarReadPhasing([
+        _make_result(v1, alt_read_names={"r1"}),
+        _make_result(v2, alt_read_names={"r2"}),
+    ])
+    assert repr(phasing) == "IsovarReadPhasing(2 variants)"
+
+
+def test_docstring_examples_run():
+    results = doctest.testmod(isovar.read_phasing, verbose=False)
+    assert results.failed == 0, (
+        "doctest failures in isovar.read_phasing: %d/%d" % (
+            results.failed, results.attempted))
+    assert results.attempted > 0, "no doctest examples were collected"
 
 
 def test_partners_in_cis_is_deterministically_ordered():

--- a/tests/test_read_phasing.py
+++ b/tests/test_read_phasing.py
@@ -19,6 +19,7 @@ import isovar.read_phasing
 from isovar import IsovarReadPhasing, run_isovar
 from isovar.allele_read import AlleleRead
 from isovar.isovar_result import IsovarResult
+from isovar.phasing import annotate_phased_variants
 from isovar.read_evidence import ReadEvidence
 
 from .common import eq_
@@ -122,13 +123,17 @@ def test_partners_in_cis_is_deterministically_ordered():
     eq_(phasing.partners_in_cis(anchor), (earlier, later, other_chrom))
 
 
-# ---- end-to-end test against the b16 RNA fixture -------------------------
+# ---- pipeline smoke tests against the b16 RNA fixture --------------------
 #
 # Runs the full Isovar pipeline on the same b16 BAM/VCF used by
-# tests/test_varcode_adapter.py. The b16 fixture is small (a handful of
-# variants), so partner sets may be empty -- the structural assertions
-# below pass either way and would still catch a regression where the
-# adapter drops, fabricates, or misroutes phasing data.
+# tests/test_varcode_adapter.py and feeds the results through
+# IsovarReadPhasing. The b16 fixture has four variants on four different
+# chromosomes, so no two variants are ever co-observed on the same read
+# -- every result's partner set is empty. These tests therefore verify
+# wiring (the adapter consumes real `run_isovar` output without errors
+# and routes the fields it claims to route), not non-empty-partner
+# behavior. The non-empty-partner path is exercised by the hand-rolled
+# tests above and the annotate_phased_variants integration test below.
 
 
 @pytest.fixture(scope="module")
@@ -176,3 +181,67 @@ def test_b16_phasing_is_symmetric(b16_results):
             assert result.variant in phasing.partners_in_cis(partner), (
                 "asymmetric phasing: %s -> %s but not back" % (
                     result.variant, partner))
+
+
+# ---- integration against the real upstream phasing logic -----------------
+#
+# `annotate_phased_variants` is the function `run_isovar` uses to
+# populate `phased_variants_in_supporting_reads`. The b16 fixture
+# doesn't produce co-phased variants, so to verify
+# IsovarReadPhasing against the real upstream logic we hand-roll
+# IsovarResult objects with overlapping read names, run them through
+# `annotate_phased_variants`, and then exercise the adapter on the
+# annotated output. This catches drift if either the upstream phasing
+# rules or the adapter's interpretation of the field changes.
+
+
+def test_adapter_consistent_with_annotate_phased_variants():
+    v1 = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    v2 = Variant("1", 20, "G", "T", normalize_contig_names=False)
+    v3 = Variant("1", 30, "T", "A", normalize_contig_names=False)
+    # v1 & v2 share reads r12a, r12b; v2 & v3 share read r23.
+    # No reads bridge v1 to v3 directly.
+    annotated = annotate_phased_variants(
+        [
+            _make_result(v1, alt_read_names={"r12a", "r12b"}),
+            _make_result(v2, alt_read_names={"r12a", "r12b", "r23"}),
+            _make_result(v3, alt_read_names={"r23"}),
+        ],
+        min_shared_fragments_for_phasing=1,
+    )
+    phasing = IsovarReadPhasing(annotated)
+
+    # Adapter must expose every partner that the upstream pipeline
+    # populated, with no additions or omissions.
+    for result in annotated:
+        eq_(
+            set(phasing.partners_in_cis(result.variant)),
+            set(result.phased_variants_in_supporting_reads))
+
+    # Spot-check the expected topology: v2 is partnered with both v1
+    # and v3; v1 and v3 partner only with v2 (not with each other,
+    # since no read spans v1 -> v3).
+    eq_(set(phasing.partners_in_cis(v1)), {v2})
+    eq_(set(phasing.partners_in_cis(v2)), {v1, v3})
+    eq_(set(phasing.partners_in_cis(v3)), {v2})
+
+    # All three have evidence.
+    for v in (v1, v2, v3):
+        assert phasing.has_evidence(v)
+
+
+def test_adapter_respects_min_shared_fragments_threshold():
+    v1 = Variant("1", 10, "A", "C", normalize_contig_names=False)
+    v2 = Variant("1", 20, "G", "T", normalize_contig_names=False)
+    # Only one read bridges v1 and v2 -- below the threshold of 2.
+    annotated = annotate_phased_variants(
+        [
+            _make_result(v1, alt_read_names={"r12", "r1only"}),
+            _make_result(v2, alt_read_names={"r12", "r2only"}),
+        ],
+        min_shared_fragments_for_phasing=2,
+    )
+    phasing = IsovarReadPhasing(annotated)
+    # Threshold filters out the single shared read, so no partners.
+    eq_(phasing.partners_in_cis(v1), ())
+    eq_(phasing.partners_in_cis(v2), ())

--- a/tests/test_read_phasing.py
+++ b/tests/test_read_phasing.py
@@ -233,7 +233,12 @@ def test_adapter_consistent_with_annotate_phased_variants():
         assert phasing.has_evidence(v)
 
 
-def test_adapter_respects_min_shared_fragments_threshold():
+def test_threshold_filter_propagates_through_adapter():
+    # The adapter is passive: it surfaces whatever
+    # annotate_phased_variants populated. This test asserts that when
+    # the upstream threshold filters out a sub-threshold pair, the
+    # adapter reports them as un-partnered (i.e. the filter
+    # propagates rather than being silently undone).
     v1 = Variant("1", 10, "A", "C", normalize_contig_names=False)
     v2 = Variant("1", 20, "G", "T", normalize_contig_names=False)
     # Only one read bridges v1 and v2 -- below the threshold of 2.
@@ -245,7 +250,6 @@ def test_adapter_respects_min_shared_fragments_threshold():
         min_shared_fragments_for_phasing=2,
     )
     phasing = IsovarReadPhasing(annotated)
-    # Threshold filters out the single shared read, so no partners.
     eq_(phasing.partners_in_cis(v1), ())
     eq_(phasing.partners_in_cis(v2), ())
 


### PR DESCRIPTION
## Summary

- Adds `isovar/read_phasing.py` with `IsovarReadPhasing`, a narrow adapter that exposes `IsovarResult.phased_variants_in_supporting_reads` via two methods: `has_evidence(variant)` and `partners_in_cis(variant)`.
- Matches the shape of varcode's new `ReadPhasingSource` Protocol (openvax/varcode#378, openvax/varcode#379) — no method renames needed.
- Re-exports the class from `isovar.__init__`.

Addresses #182. Full closure depends on the companion isovar follow-up (#184), which moves the mutant-transcript half of the existing `VarcodeAdapter` into a separate `IsovarMutantTranscript` class implementing varcode's `MutantTranscriptSource` Protocol. Both halves then plug into `varcode.ReadPhaseResolver` directly; the issue #182 acceptance test will run end-to-end after that.

## Design notes

- Backed entirely by data already on `IsovarResult` -- no new variant-identification logic.
- `has_evidence` is true iff the variant is in the input set **and** has `num_alt_fragments > 0`.
- `partners_in_cis` returns a deterministically-ordered tuple (sorted by contig, start, ref, alt) so callers can rely on ordering in snapshot tests.
- Adapter is duck-typed on three attributes (`variant`, `num_alt_fragments`, `phased_variants_in_supporting_reads`), documented in the module's "Contract" section so non-Isovar producers (long-read RNA tools, hand-rolled stubs) can target the same shape.

## Related upstream work

- openvax/varcode#378 — umbrella issue: drop Isovar-named identifiers from varcode's public phasing surface. Splits `IsovarAssemblyProvider` into `ReadPhasingSource` + `MutantTranscriptSource`; renames `IsovarPhaseResolver` → `ReadPhaseResolver`.
- openvax/varcode#379 — implementation PR for #378. `IsovarReadPhasing` plugs straight into the new `ReadPhaseResolver` once that lands.
- openvax/isovar#184 — companion isovar follow-up: split `VarcodeAdapter` into `IsovarReadPhasing` (this PR's class, unchanged) + new `IsovarMutantTranscript`. Blocks on varcode#379 merging.

## Test plan

- [x] `pytest tests/test_read_phasing.py` -- 16 unit + integration tests:
  - 8 unit tests on hand-rolled `IsovarResult`s: alt-evidence true/false, unknown variants, partners returned/empty, deterministic ordering, `__repr__`, and a `doctest.testmod` runner that executes the module's documented example.
  - 4 pipeline smoke tests against the b16 RNA fixture via `run_isovar` (the b16 fixture has 4 variants on 4 different chromosomes, so no actual co-phasing — these verify the adapter consumes real Isovar output without errors).
  - 2 integration tests driving `isovar.phasing.annotate_phased_variants` directly with hand-rolled inputs to exercise the non-empty-partner path: one for a 3-node `v1-v2-v3` topology where v1↔v3 isn't directly bridged, one for the upstream threshold propagating through.
  - 1 synthetic-BAM end-to-end test that builds 7 pysam-shaped reads via `MockAlignmentFile`/`make_pysam_read` covering a somatic SNV at chr1:4 and a nearby germline SNP at chr1:8, walks them through the full `ReadCollector` → `annotate_phased_variants` → `IsovarReadPhasing` stack, and asserts the somatic and germline calls are reported as in-cis partners. Canonical motivating scenario for openvax/varcode#268.
  - 1 doctest-runner (counted above).
- [x] `pytest tests/test_phasing.py tests/test_varcode_adapter.py` -- no regressions in adjacent phasing code.