### PR TITLE
Bump version to 1.6.0 for IsovarReadPhasing (#183)

### DIFF
--- a/isovar/__init__.py
+++ b/isovar/__init__.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.5.4"
+__version__ = "1.6.0"
 
 
 from .allele_read import AlleleRead


### PR DESCRIPTION
Minor bump (1.5.4 → 1.6.0) for the additive `IsovarReadPhasing` adapter merged in #183. Catches up the version after #183 landed without the bump-in-PR (per AGENTS.md rule #2).

After merge: run `./deploy.sh` to publish to PyPI.